### PR TITLE
Fix elasticsearch bootstrap warning

### DIFF
--- a/elasticsearch-oss/config/log4j2.properties
+++ b/elasticsearch-oss/config/log4j2.properties
@@ -3,7 +3,7 @@ status = error
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the bootstrap of elasticsearch logs the current warning:
```
[2018-12-10T20:08:57,987][WARN ][o.e.c.l.LogConfigurator  ] [elasticsearch-logging-0] Some logging configurations have %marker but don't have %node_name. We will automatically add %node_name to the pattern to ease the migration for users who customize log4j2.properties but will stop this behavior in 7.0. You should manually replace `%node_name` with `[%node_name]%marker ` in these locations:
  /usr/share/elasticsearch/config/log4j2.properties
```

With few words - `%marker` should be replaced with `[%node_name]%marker `, including the trailing space. For more information, see [elasticsearch changelog](https://www.elastic.co/guide/en/elasticsearch/reference/6.x/breaking-changes-6.5.html#_node_name_in_logging_pattern).

**Which issue(s) this PR fixes**:
Fixes a elasticsearch bootstrap warning.

**Special notes for your reviewer**:
@vlvasilev , @KristianZH

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
