### PR TITLE
Fix env variable name

### DIFF
--- a/elasticsearch-oss/run.sh
+++ b/elasticsearch-oss/run.sh
@@ -47,7 +47,7 @@ export ALLOW_DISK_ALLOCATION=${ALLOW_DISK_ALLOCATION:-true}
 # Elasticsearch will attempt to relocate shards away from a node whose disk usage is above X%
 export DISK_WATERMARK_HIGHT=${DISK_WATERMARK_HIGHT:-"90%"}
 # disk usage point beyond which ES won’t allocate new shards to that node
-export DISK_WATERMARK_HIGHT=${DISK_WATERMARK_LOW:-"85%"}
+export DISK_WATERMARK_LOW=${DISK_WATERMARK_LOW:-"85%"}
 
  #threshold for read only lock
 export DISK_WATERMARK_FLOOD_STAGE=${DISK_WATERMARK_FLOOD_STAGE:-"95%"}


### PR DESCRIPTION
**What this PR does / why we need it**:
`DISK_WATERMARK_LOW` env variable was mistyped with `DISK_WATERMARK_HIGHT`.


**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
