### PR TITLE
Fix deprecated configs of es

### DIFF
--- a/elasticsearch-oss/Tune_for_indexing_speed.md
+++ b/elasticsearch-oss/Tune_for_indexing_speed.md
@@ -206,9 +206,6 @@ All of the properties described above get used only when the cluster is restarte
 
 **TODO**: play with these settings
 
-## Switch off the  compound format
-The default segment merge policy, “tiered”, supports a compound format where data is stored in fewer files to reduce the number of open file handles needed. However, the compound format comes along with a performance penalty. There are two settings, ***index.compound_on_flush*** and ***index.compound_format***, that specify whether the compound format should be used for new segments and merged segments, respectively. Making sure that both are set to false may improve indexing performance, at the cost of more file handles.
-
 ## Increase the number of threads that may concurrently perform indexing operations on a single shard
 The setting ***index.index_concurrency*** limits the number of threads that may concurrently perform indexing operations on a single shard. Consider increasing the value, especially when there are no other shards on the node (and measure if it pays off).
 We do not use it at that moment

--- a/elasticsearch-oss/config/elasticsearch.yml
+++ b/elasticsearch-oss/config/elasticsearch.yml
@@ -15,7 +15,6 @@ path:
   logs: ${PATH_DATA}/log
 
 http:
-  enabled: ${HTTP_ENABLE}
   port: ${HTTP_PORT}
   compression: true
   cors:
@@ -36,10 +35,8 @@ indices:
     index_buffer_size: ${INDEX_BUFFER_SIZE}
 
 thread_pool:
-  index:
-    queue_size: ${INDEX_QUEUE_SIZE}
-  bulk:
-    queue_size: ${BULK_QUEUE_SIZE}
+  write:
+    queue_size: ${WRITE_QUEUE_SIZE}
 
 cluster:
   name: ${CLUSTER_NAME}

--- a/elasticsearch-oss/run.sh
+++ b/elasticsearch-oss/run.sh
@@ -24,7 +24,6 @@ export NODE_NAME=${NODE_NAME:-${HOSTNAME}}
 export NODE_MASTER=${NODE_MASTER:-true}
 export NODE_DATA=${NODE_DATA:-true}
 export NODE_INGEST=${NODE_INGEST:-true}
-export HTTP_ENABLE=${HTTP_ENABLE:-true}
 export HTTP_PORT=${HTTP_PORT:-9200}
 export TRANSPORT_PORT=${TRANSPORT_PORT:-9300}
 export HTTP_CORS_ENABLE=${HTTP_CORS_ENABLE:-false}
@@ -38,11 +37,9 @@ export DISCOVERY_SERVICE=${DISCOVERY_SERVICE:-"elasticsearch-logging"}
 #10% of the total heap allocated to a node will be used as 
 #the indexing buffer size shared across all shards.
 export INDEX_BUFFER_SIZE=${INDEX_BUFFER_SIZE:-"10%"}
-#adjust the index query size
-export INDEX_QUEUE_SIZE=${INDEX_QUEUE_SIZE:-200}
-#adjust the bulk query size
-export INDEX_QUEUE_SIZE=${BULK_QUEUE_SIZE:-200}
-#enaable the disk allocation decider.
+#adjust the write queue size
+export WRITE_QUEUE_SIZE=${WRITE_QUEUE_SIZE:-200}
+#enable the disk allocation decider
 export ALLOW_DISK_ALLOCATION=${ALLOW_DISK_ALLOCATION:-true}
 # Elasticsearch will attempt to relocate shards away from a node whose disk usage is above X%
 export DISK_WATERMARK_HIGHT=${DISK_WATERMARK_HIGHT:-"90%"}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the bootstrap of elasticsearch logs the current warning:
```
[...]
[2018-12-10T20:08:59,888][WARN ][o.e.d.c.s.Settings       ] [elasticsearch-logging-0] [thread_pool.index.queue_size] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
[2018-12-10T20:08:59,894][WARN ][o.e.d.c.s.Settings       ] [elasticsearch-logging-0] [thread_pool.bulk.queue_size] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
[2018-12-10T20:09:02,116][WARN ][o.e.d.c.s.Settings       ] [elasticsearch-logging-0] [http.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
[...]
```

With few words:
- `http.enabled` setting is removed and HTTP is enabled by default [#12792](https://github.com/elastic/elasticsearch/issues/12792)
- Index thread pool settings are removed [link](https://github.com/elastic/elasticsearch/blob/master/docs/reference/migration/migrate_7_0/settings.asciidoc#index-thread-pool)
- `thread_pool.bulk` renamed to `thread_pool.write` [link](https://github.com/elastic/elasticsearch/blob/master/docs/reference/migration/migrate_7_0/settings.asciidoc#write-thread-pool-fallback)

**Which issue(s) this PR fixes**:
Fixes a elasticsearch bootstrap warnings for deprecated configs.

**Special notes for your reviewer**:
@vlvasilev , @KristianZH, @vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
