### PR TITLE
Add elasticsearch_dynamic_fault_tolerant plugin

### DIFF
--- a/fluentd-es/Dockerfile
+++ b/fluentd-es/Dockerfile
@@ -15,6 +15,7 @@
 FROM k8s.gcr.io/fluentd-elasticsearch:v2.4.0
 
 COPY fluentd-es/Gemfile.gardener /Gemfile.gardener
+COPY fluentd-es/plugin/out_elasticsearch_dynamic_fault_tolerant.rb /etc/fluent/plugin/
 
 RUN BUILD_DEPS="make gcc g++ libc6-dev ruby-dev" \
     && clean-install $BUILD_DEPS \

--- a/fluentd-es/plugin/out_elasticsearch_dynamic_fault_tolerant.rb
+++ b/fluentd-es/plugin/out_elasticsearch_dynamic_fault_tolerant.rb
@@ -1,0 +1,40 @@
+# encoding: UTF-8
+require 'fluent/plugin/out_elasticsearch_dynamic'
+
+module Fluent::Plugin
+  class ElasticsearchOutputDynamicFaultTolerant < ElasticsearchOutputDynamic
+
+    Fluent::Plugin.register_output('elasticsearch_dynamic_fault_tolerant', self)
+
+    def configure(conf)
+      super
+    end
+
+    def write(chunk)
+      super
+    end
+
+    def send_bulk(data, host, index)
+      begin
+        response = client(host).bulk body: data, index: index
+        if response['errors']
+          log.error "Could not push log to Elasticsearch: #{response}"
+        end
+      rescue => e
+        @_es = nil if @reconnect_on_error
+
+        # if the elastic service is not present or no elastic instance is able to handle a request
+        # the idea of this if statement is to prevent clearing of queue for exceeded limit of retries 
+        if !e.message.nil? &&
+            (e.message.include?("getaddrinfo: Name or service not known (SocketError)") ||
+                e.message.include?("connect_write timeout reached"))
+            log.error "could not push logs to Elasticsearch cluster (#{connection_options_description(host)}): #{e.message}"
+            return
+        end
+        
+        # FIXME: identify unrecoverable errors and raise UnrecoverableRequestFailure instead
+        raise RecoverableRequestFailure, "could not push logs to Elasticsearch cluster (#{connection_options_description(host)}): #{e.message}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:
Fluentd discards all chunks in the buffer queue when a single chunk is failed ([see](https://docs.fluentd.org/v1.0/articles/buffer-plugin-overview)). In general it is okay because in majority of the cases the output host is fixed. In our case it is not fixed and it depends on the namespace name of the log message:

```
host elasticsearch-logging.${record['kubernetes']['namespace_name']}.svc
```

The current behaviour drops all chunks and this leads to major data loss. See below the results from the testing. The test runs 10 clients and each clients logs 20000 messages and a new clients is scheduled after 20 seconds from the previous.

```
go run cmd/main.go \
  --seed-kubeconfig <path-to-kubeconfig> \
  --shoot-namespace <shoot-ns> \
  --clients 10 \
  --log-messages 20000 \
  --wait-interval 20
```

- Without this PR:

```
| # | Expected | Actual  |
|---|----------|---------|
| 1 | 200 000  | 108 438 |
| 2 | 200 000  |  99 494 |
| 3 | 200 000  |  78 705 |
| 4 | 200 000  |  84 643 |
```

- With this PR:

```
| # | Expected | Actual  |
|---|----------|---------|
| 1 | 200 000  | 200 000 |
| 2 | 200 000  | 200 000 |
| 3 | 200 000  | 200 000 |
| 4 | 200 000  | 200 000 |
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Now fluentd does not lose log messages.
```
