### PR TITLE
Update golang to 1.12.0

### DIFF
--- a/curator-es/Dockerfile
+++ b/curator-es/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.11.5 AS builder
+FROM golang:1.12.0 AS builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
https://golang.org/doc/go1.12

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The golang version has been upgraded to `v1.12.0`.
```
