### PR TITLE
Update fluentd image to v2.5.0

### DIFF
--- a/fluentd-es/Dockerfile
+++ b/fluentd-es/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/fluentd-elasticsearch:v2.4.0
+FROM gcr.io/fluentd-elasticsearch/fluentd:v2.5.0
 
 COPY fluentd-es/Gemfile.gardener /Gemfile.gardener
 COPY fluentd-es/plugin/out_elasticsearch_dynamic_fault_tolerant.rb /etc/fluent/plugin/


### PR DESCRIPTION
**What this PR does / why we need it**:
Adopt kubernetes/kubernetes#74616 .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
 
**Release note**:

```improvement operator
fluentd image version has beed upgraded to v2.5.0.
```
