### PR TITLE
updated curator 5.6.0->5.8.1, python 2.7->3.7

### DIFF
--- a/curator-es/Dockerfile
+++ b/curator-es/Dockerfile
@@ -22,9 +22,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install ./curator-es/...
 
 ############# curator-es & curator #############
 
-FROM python:2.7-slim
+FROM python:3.7-slim
 
 COPY --from=builder /go/bin/curator-es /bin
-RUN pip install elasticsearch-curator==5.6.0
+RUN pip install elasticsearch-curator==5.8.1
 
 ENTRYPOINT [ "/usr/local/bin/curator" ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Elasticearch curator has been update from 5.6.0 to 5.8.1 (https://github.com/elastic/curator/releases/tag/v5.8.1) to accomodate for elasticsearch versions >= 7.0

As curator started in 5.8.0 to use python 3.7 as default (instead of 2.7) (https://github.com/elastic/curator/releases/tag/v5.8.0), I've bumped the base python image from 2.7 to 3.7 as well.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
es curator was updated from 5.6.0 to 5.8.1, the python base image was updated from 2.7 to 3.7
```