### PR TITLE
Pin fluentd version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your release note in the below block.
+2. If no release note is required, just write "NONE" within the block.
+
+Format of block header: <category> <target_group>
+Possible values:
+- category:       improvement|noteworthy|action
+- target_group:   user|operator|developer
+-->
+```improvement operator
+
+```

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
 # logging maintainers
-*   @vlvasilev
-*   @ialidzhikov
-*   @vpnachev
+* @vlvasilev @ialidzhikov @vpnachev

--- a/curator-es/Dockerfile
+++ b/curator-es/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.12.1 AS builder
+FROM golang:1.13.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .

--- a/fluentd-es/Gemfile.gardener
+++ b/fluentd-es/Gemfile.gardener
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'fluentd', '<=1.4.2'
+gem 'fluent-plugin-elasticsearch', '~>3.4.3'
 gem 'fluent-plugin-rewrite-tag-filter', '~>2.1.0'
+gem 'fluent-plugin-systemd', '~>1.0.2'


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin fluend version in the gem file. Currently on new docker image the latest fluentd is fetched which results in backwards incompatible change with some plugins:
```
2019-12-13 13:33:08 +0000 [error]: unexpected error error_class=NoMethodError error="undefined method `dry_run_mode' for #<Fluent::EngineClass:0x007f7e9f31f4f0>"
  2019-12-13 13:33:08 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.4.3/lib/fluent/plugin/out_elasticsearch.rb:187:in `configure'
  2019-12-13 13:33:08 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.8.0/lib/fluent/plugin.rb:173:in `configure'
  2019-12-13 13:33:08 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.8.0/lib/fluent/agent.rb:132:in `add_match'
  2019-12-13 13:33:08 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.8.0/lib/fluent/agent.rb:74:in `block in configure'
  2019-12-13 13:33:08 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.8.0/lib/fluent/agent.rb:64:in `each'
  2019-12-13 13:33:08 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.8.0/lib/fluent/agent.rb:64:in `configure'
```

Without this PR the fetched fluentd by default is `fluentd-1.8.0`.
This PR pins it to `fluentd-1.4.2`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```