### PR TITLE
remove-warn-message-when-could-not-find-client-for-testing-clusters

### DIFF
--- a/fluent-bit-to-loki/pkg/controller/controller_test.go
+++ b/fluent-bit-to-loki/pkg/controller/controller_test.go
@@ -190,6 +190,15 @@ var _ = Describe("Controller", func() {
 				Expect(c).To(BeNil())
 				Expect(ok).To(BeFalse())
 			})
+			It("Should not overwrite new client for a cluster in hibernation", func() {
+				name := "new-shoot-name"
+				newNameCluster := hibernatedCluster.DeepCopy()
+				newNameCluster.Name = name
+				ctl.addFunc(hibernatedCluster)
+				ctl.addFunc(newNameCluster)
+				Expect(ctl.clientConfig.URL.String()).ToNot(Equal(ctl.dynamicHostPrefix + name + ctl.dynamicHostSulfix))
+				Expect(ctl.clientConfig.URL.String()).ToNot(Equal(ctl.dynamicHostPrefix + hibernatedCluster.Name + ctl.dynamicHostSulfix))
+			})
 
 		})
 

--- a/fluent-bit-to-loki/pkg/lokiplugin/loki.go
+++ b/fluent-bit-to-loki/pkg/lokiplugin/loki.go
@@ -85,7 +85,7 @@ func (l *loki) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	client := l.getClient(dynamicHostName)
 
 	if client == nil {
-		return fmt.Errorf("could not found client for %s", dynamicHostName)
+		return level.Debug(l.logger).Log("host", dynamicHostName, "issue", "could_not_find_client")
 	}
 
 	if l.cfg.DropSingleKey && len(records) == 1 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove warn messages when we could not find client for testing shoots
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
