### PR TITLE
Change the pipeline definition public section to use Dockerfile from c…

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -11,7 +11,7 @@ logging:
           fluent-bit-to-loki:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki'
-            dockerfile: 'fluent-bit-to-loki/Dockerfile'
+            dockerfile: './Dockerfile'
     steps:
       check:
         image: 'golang:1.12.1'


### PR DESCRIPTION
…urrent direcotory

**What this PR does / why we need it**:
This PR change the public section of the pipeline definition to use the Dockerfile from the current directory instead from `fluent-bit-to-loki` directory.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Pipeline definition will use ./Dockerfile instead of fluent-bit-to-loki/Dockerfile
```
