### PR TITLE
remove check ci job

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -1,54 +1,17 @@
 #!/usr/bin/env bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
-# For the check step concourse will set the following environment variables:
-# SOURCE_PATH - path to component repository root directory.
+cd "$(dirname $0)/.."
 
-if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
-else
-  export SOURCE_PATH="$(readlink -f ${SOURCE_PATH})"
-fi
+git config --global user.email "gardener@sap.com"
+git config --global user.name "Gardener CI/CD"
 
-# The `go <cmd>` commands requires to see the target repository to be part of a
-# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
-# temporarily by using symbolic links.
-if [[ "${SOURCE_PATH}" != *"src/github.com/gardener/logging" ]]; then
-  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/github.com/gardener/logging"
-  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
-    rm -rf "${SOURCE_PATH}/tmp"
-  fi
-  mkdir -p "${SOURCE_PATH}/tmp/src/github.com/gardener"
-  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
-  cd "${SOURCE_SYMLINK_PATH}"
+apt-get update
+apt-get install -y unzip
 
-  export GOPATH="${SOURCE_PATH}/tmp"
-  export GOBIN="${SOURCE_PATH}/tmp/bin"
-  export PATH="${GOBIN}:${PATH}"
-fi
-
-# Install Golint.
-if ! which golint 1>/dev/null; then
-  echo -n "Installing golint... "
-  go get -u golang.org/x/lint/golint
-  echo "done."
-fi
-
-###############################################################################
-
-PACKAGES="$(go list -e ./... | grep -vE '/tmp/|/vendor/|/fluent-bit-to-loki/')"
-LINT_FOLDERS="$(echo ${PACKAGES} | sed "s|github.com/gardener/logging|.|g")"
-
-# Execute static code checks.
-go vet ${PACKAGES}
-
-# Execute automatic code formatting directive.
-go fmt ${PACKAGES}
-
-# Execute lint checks.
-for package in ${LINT_FOLDERS}; do
-  golint -set_exit_status $package
-done
-
-
+mkdir -p /go/src/github.com/gardener/logging
+cp -r . /go/src/github.com/gardener/logging
+cd /go/src/github.com/gardener/logging

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,8 +13,6 @@ logging:
             image: 'eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki'
             dockerfile: './Dockerfile'
     steps:
-      check:
-        image: 'golang:1.12.1'
       verify:
         image: 'golang:1.14.2'
   jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+#############      builder       #############
+FROM golang:1.14.2 AS builder
+
+WORKDIR /go/src/github.com/gardener/logging/fluent-bit-to-loki
+COPY ./fluent-bit-to-loki .
+
+RUN  make plugin
+#############      fluent-bit       #############
+FROM fluent/fluent-bit:1.5.4 AS fluent-bit
+
+COPY --from=builder /go/src/github.com/gardener/logging/fluent-bit-to-loki/build /fluent-bit/plugins
+
+WORKDIR /
+
+ENTRYPOINT ["/fluent-bit/bin/fluent-bit"]


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we remove the check job as it useless. After cleaning up the fluentd-es and curator-es the `verify`  job will call check.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Remove `check` job in the CI
```
