### PR TITLE
Add docker-id from the kubernetes metadata to the log stream

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,7 @@ const (
 	// KvPairFormat represents key-value format for log line
 	KvPairFormat
 	// DefaultKubernetesMetadataTagExpression for extracting the kubernetes metadata from tag
-	DefaultKubernetesMetadataTagExpression = "\\.(.+?)_(.+?)_(.+)-.*\\.log"
+	DefaultKubernetesMetadataTagExpression = "\\.([^_]+)_([^_]+)_(.+)-([a-z0-9]{64})\\.log$"
 
 	// DefaultKubernetesMetadataTagKey represents the key for the tag in the entry
 	DefaultKubernetesMetadataTagKey = "tag"

--- a/pkg/lokiplugin/utils.go
+++ b/pkg/lokiplugin/utils.go
@@ -23,9 +23,11 @@ import (
 )
 
 const (
-	podName       = "pod_name"
-	namespaceName = "namespace_name"
-	containerName = "container_name"
+	podName            = "pod_name"
+	namespaceName      = "namespace_name"
+	containerName      = "container_name"
+	dockerID           = "docker_id"
+	subExpresionNumber = 5
 )
 
 // prevent base64-encoding []byte values (default json.Encoder rule) by
@@ -83,7 +85,7 @@ func autoLabels(records map[string]interface{}, kuberneteslbs model.LabelSet) er
 			for m, n := range v.(map[string]interface{}) {
 				kuberneteslbs[model.LabelName(replacer.Replace(m))] = model.LabelValue(fmt.Sprintf("%v", n))
 			}
-		case "docker_id", "pod_id", "annotations":
+		case "pod_id", "annotations":
 			// do nothing
 			continue
 		default:
@@ -101,7 +103,7 @@ func extractKubernetesMetadataFromTag(records map[string]interface{}, tagKey str
 	}
 
 	kubernetesMetaData := re.FindStringSubmatch(tag)
-	if len(kubernetesMetaData) != 4 {
+	if len(kubernetesMetaData) != subExpresionNumber {
 		return fmt.Errorf("invalid format for tag %v. The tag should be in format: %s", tag, re.String())
 	}
 
@@ -109,6 +111,7 @@ func extractKubernetesMetadataFromTag(records map[string]interface{}, tagKey str
 		podName:       kubernetesMetaData[1],
 		namespaceName: kubernetesMetaData[2],
 		containerName: kubernetesMetaData[3],
+		dockerID:      kubernetesMetaData[4],
 	}
 
 	return nil

--- a/pkg/lokiplugin/utils_test.go
+++ b/pkg/lokiplugin/utils_test.go
@@ -495,6 +495,7 @@ var _ = Describe("Loki plugin utils", func() {
 						podName:       "cluster-autoscaler-65d4ccbb7d-w5kd2",
 						containerName: "cluster-autoscaler",
 						namespaceName: "shoot--i355448--local-shoot",
+						dockerID:      "a8bba03512b5dd378c620ab3707aec013f83bdb9abae08d347e1644b064ed35f",
 					},
 				},
 				err: nil,


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add the `docker_id` from the kubernetes metadata to the log stream.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Extract `docker_id` from the log tag to the kubernetes metadata when `FallbackToTagWhenMetadataIsMissing` flag is set.
```
```improvement operator
Add `docker_id` from the kubernetes metadata to the log stream when `AutoKubernetesLabels` flag is set
```
