### PR TITLE
stop using the fluent-bit image as the fluent-bit-to-loki plugin carrier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ WORKDIR /go/src/github.com/gardener/logging
 COPY . .
 
 RUN  make plugin
-#############      fluent-bit       #############
-FROM fluent/fluent-bit:1.5.4 AS fluent-bit
+#############      carrier       #############
+FROM alpine:3.12.0 AS carrier
 
-COPY --from=builder /go/src/github.com/gardener/logging/build /fluent-bit/plugins
+COPY --from=builder /go/src/github.com/gardener/logging/build /source/plugins
 
 WORKDIR /
-
-ENTRYPOINT ["/fluent-bit/bin/fluent-bit"]


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we separate the fluent-bit-to-loki plugin lifecycle from fluent-bit image.
The plugin will be hold in slim container image and installed via init container.

**Which issue(s) this PR fixes**:
Fixes [#62](https://github.com/gardener/logging/issues/62)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Separate the fluent-bit-to-loki plugin build from a specific fluent-bit image.
```
