### PR TITLE
Change log verbosity when metadata is missing

### DIFF
--- a/pkg/lokiplugin/loki.go
+++ b/pkg/lokiplugin/loki.go
@@ -81,7 +81,7 @@ func (l *loki) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	// Check if metadata is missing
 	if l.cfg.KubernetesMetadata.FallbackToTagWhenMetadataIsMissing {
 		if _, ok := records["kubernetes"]; !ok {
-			level.Warn(l.logger).Log("msg", fmt.Sprintf("kubernetes metadata is missing. Will try to extract it from the tag %q", l.cfg.KubernetesMetadata.TagKey), "records", fmt.Sprintf("%+v", records))
+			level.Debug(l.logger).Log("msg", fmt.Sprintf("kubernetes metadata is missing. Will try to extract it from the tag %q", l.cfg.KubernetesMetadata.TagKey), "records", fmt.Sprintf("%+v", records))
 			err := extractKubernetesMetadataFromTag(records, l.cfg.KubernetesMetadata.TagKey, l.extractKubernetesMetadataRegexp)
 			if err != nil {
 				level.Error(l.logger).Log("msg", err.Error(), "records", fmt.Sprintf("%+v", records))


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the log verbosity when metadata is missing.
This is needed because when we remove the k8s filter, fluent-bit will start flooding a lot of warnings that the metadata is missing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
