### PR TITLE
change plugin name to gardenerloki

### DIFF
--- a/cmd/out_loki.go
+++ b/cmd/out_loki.go
@@ -61,7 +61,7 @@ func (c *pluginConfig) Get(key string) string {
 
 //export FLBPluginRegister
 func FLBPluginRegister(ctx unsafe.Pointer) int {
-	return output.FLBPluginRegister(ctx, "loki", "Ship fluent-bit logs to Grafana Loki")
+	return output.FLBPluginRegister(ctx, "gardenerloki", "Ship fluent-bit logs to Grafana Loki")
 }
 
 //export FLBPluginInit


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR change the name of the custom fluent-bit-to-loki plugin to `gardenerloki` because since fluent-bit 1.6 there is a plugin named `loki` which leads to collision. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Change the name of the fluent-bit-to-loki plugin to `gardenerloki`
```
