### PR TITLE
Remove double decrementation of a wait group when closing a client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -114,8 +114,6 @@ func (c *sortedClient) run() {
 	for {
 		select {
 		case <-c.quit:
-			c.sendBatch()
-			c.wg.Done()
 			return
 
 		case e := <-c.entries:


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we fix the double decrement of the wait group when closing the sortedClient.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Remove double decrementation of the wait group when closing a client.
```
