### PR TITLE
make the batch ID number configurable and some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ It also adds additional configurations that aim to improve plugin's performance 
 | QueueDir | Path to a directory where the buffer will store its records. | '/tmp/flb-storage/loki'
 | QueueSegmentSize | The number of entries stored into the buffer. | 500
 | QueueName | The name of the file where the log entries will be stored | `dque`
-| ReplaceOutOfOrderTS | Overwrites the timestamp of out of order records. Their timestamp will replaced with the timestamp of the last entry. | `false`
+| SortByTimestamp | Sort the logs by their timestamps. | `false`
 | FallbackToTagWhenMetadataIsMissing | If set the plugin will try to extract the `namespace`, `pod_name` and `container_name` from the tag when the metadata is missing | `false`
 | TagKey | The key of the record which holds the tag. The tag should not be nested | "tag"
 | TagPrefix | The prefix of the tag. In the prefix no metadata will be searched. The prefix must not contain group expression(`()`). | none
 | TagExpression | The regex expression which will be used for matching the metadata retrieved from the tag. It contains 3 group expressions (`()`): `pod name`, `namespace` and the `container name` | "\\.(.*)_(.*)_(.*)-.*\\.log"
 | DropLogEntryWithoutK8sMetadata | When metadata is missing for the log entry, it will be dropped | `false`
-
+| ControllerSyncTimeout | Time to wait for cluster object synchronization | 60 seconds
+| NumberOfBatchIDs | The number of id per batch. This increase the number of loki label streams | 10
 
 ### Labels
 
@@ -110,7 +111,7 @@ To configure the Loki output plugin add this section to fluent-bit.conf
     BatchSize 30720
     Labels {test="fluent-bit-go"}
     LineFormat json
-    ReplaceOutOfOrderTS true
+    SortByTimestamp true
     DropSingleKey false
     AutoKubernetesLabels false
     LabelSelector gardener.cloud/role:shoot
@@ -145,7 +146,7 @@ To configure the Loki output plugin add this section to fluent-bit.conf
     BatchSize 30720
     Labels {test="fluent-bit-go", lang="Golang"}
     LineFormat json
-    ReplaceOutOfOrderTS true
+    SortByTimestamp true
     DropSingleKey false
     AutoKubernetesLabels true
     LabelSelector gardener.cloud/role:shoot
@@ -180,7 +181,7 @@ To configure the Loki output plugin add this section to fluent-bit.conf
     BatchSize 30720
     Labels {test="fluent-bit-go"}
     LineFormat json
-    ReplaceOutOfOrderTS true
+    SortByTimestamp true
     DropSingleKey false
     RemoveKeys kubernetes,stream,hostname,unit
     LabelMapPath /fluent-bit/etc/systemd_label_map.json

--- a/example.config
+++ b/example.config
@@ -79,7 +79,7 @@
     # (30KiB)
     Labels {test="fluent-bit-go", lang="Golang"}
     LineFormat json
-    ReplaceOutOfOrderTS true
+    SortByTimestamp true
     DropSingleKey false
     AutoKubernetesLabels true
     LabelSelector gardener.cloud/role:shoot
@@ -113,7 +113,7 @@
     # (30KiB)
     Labels {test="fluent-bit-go", lang="Golang"}
     LineFormat json
-    ReplaceOutOfOrderTS true
+    SortByTimestamp true
     DropSingleKey false
     RemoveKeys kubernetes,stream,hostname,unit
     LabelMapPath /fluent-bit/etc/systemd_label_map.json

--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -38,7 +38,7 @@ func NewBatch(id uint64) *Batch {
 		Streams:   make(map[string]*Stream),
 		Bytes:     0,
 		CreatedAt: time.Now(),
-		id:        id % 10,
+		id:        id,
 	}
 
 	return b

--- a/pkg/batch/batch_test.go
+++ b/pkg/batch/batch_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Batch", func() {
 	Describe("#NewBatch", func() {
 		It("Should create new batch", func() {
 			var id uint64 = 11
-			batch := NewBatch(id)
+			batch := NewBatch(id % 10)
 			Expect(batch).ToNot(BeNil())
 			Expect(batch.Streams).ToNot(BeNil())
 			Expect(batch.Bytes).To(Equal(0))

--- a/pkg/buffer/dque.go
+++ b/pkg/buffer/dque.go
@@ -107,8 +107,11 @@ func (c *dqueClient) dequeuer() {
 
 // Stop the client
 func (c *dqueClient) Stop() {
-	c.once.Do(func() { c.queue.Close() })
-	c.loki.Stop()
+	c.once.Do(func() {
+		c.queue.Close()
+		c.loki.Stop()
+	})
+
 }
 
 // Handle implement EntryHandler; adds a new line to the next batch; send is async.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Config", func() {
 				Expect(args.want.LineFormat).To(Equal(got.LineFormat))
 				//Expect(args.want.LogLevel).To(Equal(got.LogLevel))
 				Expect(args.want.RemoveKeys).To(Equal(got.RemoveKeys))
-				Expect(args.want.ReplaceOutOfOrderTS).To(Equal(got.ReplaceOutOfOrderTS))
+				Expect(args.want.SortByTimestamp).To(Equal(got.SortByTimestamp))
 				Expect(args.want.KubernetesMetadata).To(Equal(got.KubernetesMetadata))
 			}
 		},
@@ -116,17 +116,17 @@ var _ = Describe("Config", func() {
 		),
 		Entry("setting values", testArgs{
 			map[string]string{
-				"URL":                 "http://somewhere.com:3100/loki/api/v1/push",
-				"TenantID":            "my-tenant-id",
-				"LineFormat":          "key_value",
-				"LogLevel":            "warn",
-				"Labels":              `{app="foo"}`,
-				"BatchWait":           "30",
-				"BatchSize":           "100",
-				"RemoveKeys":          "buzz,fuzz",
-				"LabelKeys":           "foo,bar",
-				"DropSingleKey":       "false",
-				"ReplaceOutOfOrderTS": "true",
+				"URL":             "http://somewhere.com:3100/loki/api/v1/push",
+				"TenantID":        "my-tenant-id",
+				"LineFormat":      "key_value",
+				"LogLevel":        "warn",
+				"Labels":          `{app="foo"}`,
+				"BatchWait":       "30",
+				"BatchSize":       "100",
+				"RemoveKeys":      "buzz,fuzz",
+				"LabelKeys":       "foo,bar",
+				"DropSingleKey":   "false",
+				"SortByTimestamp": "true",
 			},
 			&Config{
 				LineFormat: KvPairFormat,
@@ -153,12 +153,12 @@ var _ = Describe("Config", func() {
 						QueueName:        DefaultDqueConfig.QueueName,
 					},
 				},
-				ReplaceOutOfOrderTS: true,
-				LogLevel:            warnLogLevel,
-				LabelKeys:           []string{"foo", "bar"},
-				RemoveKeys:          []string{"buzz", "fuzz"},
-				DropSingleKey:       false,
-				DynamicHostRegex:    "*",
+				SortByTimestamp:  true,
+				LogLevel:         warnLogLevel,
+				LabelKeys:        []string{"foo", "bar"},
+				RemoveKeys:       []string{"buzz", "fuzz"},
+				DropSingleKey:    false,
+				DynamicHostRegex: "*",
 				KubernetesMetadata: KubernetesMetadataExtraction{
 					TagKey:        DefaultKubernetesMetadataTagKey,
 					TagPrefix:     DefaultKubernetesMetadataTagPrefix,
@@ -522,7 +522,7 @@ var _ = Describe("Config", func() {
 		Entry("bad labelmap file", testArgs{map[string]string{"LabelMapPath": "a"}, nil, true}),
 		Entry("bad Dynamic Host Path", testArgs{map[string]string{"DynamicHostPath": "a"}, nil, true}),
 		Entry("bad Buffer ", testArgs{map[string]string{"Buffer": "a"}, nil, true}),
-		Entry("bad ReplaceOutOfOrderTS value", testArgs{map[string]string{"ReplaceOutOfOrderTS": "3"}, nil, true}),
+		Entry("bad SortByTimestamp value", testArgs{map[string]string{"SortByTimestamp": "3"}, nil, true}),
 		Entry("bad MaxRetries value", testArgs{map[string]string{"MaxRetries": "a"}, nil, true}),
 		Entry("bad Timeout value", testArgs{map[string]string{"Timeout": "a"}, nil, true}),
 		Entry("bad MinBackoff value", testArgs{map[string]string{"MinBackoff": "a"}, nil, true}),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -66,45 +66,36 @@ var _ = Describe("Controller", func() {
 		}
 
 		It("Should return existing client", func() {
-			c := ctl.GetClient("shoot--dev--test1")
+			c, _ := ctl.GetClient("shoot--dev--test1")
 			Expect(c).ToNot(BeNil())
 		})
 
-		It("Sould return nil when client name is empty", func() {
-			c := ctl.GetClient("")
+		It("Should return nil when client name is empty", func() {
+			c, _ := ctl.GetClient("")
 			Expect(c).To(BeNil())
 		})
 
-		It("Sould not return client for not existing one", func() {
-			c := ctl.GetClient("shoot--dev--notexists")
+		It("Should not return client for not existing one", func() {
+			c, _ := ctl.GetClient("shoot--dev--notexists")
 			Expect(c).To(BeNil())
 		})
 	})
 
 	Describe("#Stop", func() {
+		shootDevTest1 := &fakeLokiClient{}
+		shootDevTest2 := &fakeLokiClient{}
 		ctl := &controller{
 			clients: map[string]lokiclient.Client{
-				"shoot--dev--test1": &fakeLokiClient{},
-				"shoot--dev--test2": &fakeLokiClient{},
+				"shoot--dev--test1": shootDevTest1,
+				"shoot--dev--test2": shootDevTest2,
 			},
-			stopChn: make(chan struct{}),
 		}
-		//errorChan := make(chan struct{})
+
 		It("Should stops propperly ", func() {
 			ctl.Stop()
-
-			select {
-			case <-ctl.stopChn:
-				for k, v := range ctl.clients {
-					err := v.Handle(nil, time.Time{}, k)
-					Expect(err).To(HaveOccurred())
-				}
-				return
-			default:
-				err := fmt.Errorf("Stop controller was not triggered")
-				Expect(err).ToNot(HaveOccurred())
-				return
-			}
+			Expect(ctl.clients).To(BeNil())
+			Expect(shootDevTest1.isStopped).To(BeTrue())
+			Expect(shootDevTest2.isStopped).To(BeTrue())
 		})
 	})
 	Describe("Event functions", func() {
@@ -187,7 +178,6 @@ var _ = Describe("Controller", func() {
 			}
 			ctl = &controller{
 				clients: make(map[string]lokiclient.Client),
-				stopChn: make(chan struct{}),
 				conf:    conf,
 				decoder: decoder,
 				logger:  logger,

--- a/pkg/lokiplugin/loki_test.go
+++ b/pkg/lokiplugin/loki_test.go
@@ -74,11 +74,11 @@ type fakeController struct {
 	clients map[string]lokiclient.Client
 }
 
-func (ctl *fakeController) GetClient(name string) lokiclient.Client {
+func (ctl *fakeController) GetClient(name string) (lokiclient.Client, bool) {
 	if client, ok := ctl.clients[name]; ok {
-		return client
+		return client, false
 	}
-	return nil
+	return nil, false
 }
 
 func (ctl *fakeController) Stop() {}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we make the number on batch IDs configurable via `NumberOfBatchIDs`.
We add `ControllerSyncTimeout` to control the informer sync period. Prior it was infinity time.
 `ReplaceOutOfOrderTS` is replaces by `SortByTimestamp`. The timestamp is no longer replaced. Instead log are sorted by their timestamp.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Batch IDs are configurable via `NumberOfBatchIDs`.
```
```improvement operator
Add `ControllerSyncTimeout` to control the informer sync period. Prior it was infinity time.
```
```improvement operator
`ReplaceOutOfOrderTS` is replaces by `SortByTimestamp`. The timestamp is no longer replaced. Instead the logs are sorted by their timestamp.
```