### PR TITLE
Move forwarded_log counter to the end of the plugin and add IncomingL…

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,6 +43,13 @@ var (
 		Help:      "Total number of incoming logs in the Loki Gardener",
 	}, []string{"host"})
 
+	// IncomingLogsWithEndpoint is a prometheus metric which keeps the number of incoming logs with endpoint
+	IncomingLogsWithEndpoint = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "incoming_logs_with_endpoint_total",
+		Help:      "Total number of incoming logs with endpoint in the Loki Gardener",
+	}, []string{"host"})
+
 	// ForwardedLogs is a prometheus metric which keeps forwarded logs to the Promtail Client
 	ForwardedLogs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,


### PR DESCRIPTION
…ogsWithEndpoint metric

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging
/priority normal

**What this PR does / why we need it**:
With this PR we move the `ForwardedLogs` metric to the end of the fluent-bit which is the [promtail client](https://github.com/grafana/loki/tree/master/pkg/promtail/client). Also we add new metric `IncomingLogsWithEndpoint` which counts the number of incoming logs which have endpoint and will be processed by the plugin to its end.

**Which issue(s) this PR fixes**:
Fixes [# 87](https://github.com/gardener/logging/issues/87)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`forwarded_log_total` metric reflect the real number of forwarded to promtail client logs
```
```other operator
`incoming_logs_with_endpoint_total` metric is added to count the number of logs with endpoints which are going to be forwarded to promtail client.
```