### PR TITLE
implement graceful shut down

### DIFF
--- a/cmd/fluent-bit-loki-plugin/out_loki.go
+++ b/cmd/fluent-bit-loki-plugin/out_loki.go
@@ -47,15 +47,17 @@ var (
 )
 
 func init() {
-	// metrics
-	go func() {
-		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(":2021", nil)
-	}()
-
 	var logLevel logging.Level
 	_ = logLevel.Set("info")
 	logger = log.With(newLogger(logLevel), "ts", log.DefaultTimestampUTC, "caller", "main")
+
+	// metrics
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		if err := http.ListenAndServe(":2021", nil); err != nil {
+			level.Error(logger).Log("Fluent-bit-gardener-output-plugin", err.Error())
+		}
+	}()
 
 	kubernetesCleint, err := getInclusterKubernetsClient()
 	if err != nil {

--- a/pkg/buffer/buffer.go
+++ b/pkg/buffer/buffer.go
@@ -10,13 +10,14 @@ import (
 	"fmt"
 
 	"github.com/gardener/logging/pkg/config"
+	"github.com/gardener/logging/pkg/types"
 
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/loki/pkg/promtail/client"
 )
 
 // NewBuffer makes a new buffered Client.
-func NewBuffer(cfg *config.Config, logger log.Logger, newClientFunc func(cfg client.Config, logger log.Logger) (client.Client, error)) (client.Client, error) {
+func NewBuffer(cfg *config.Config, logger log.Logger, newClientFunc func(cfg client.Config, logger log.Logger) (types.LokiClient, error)) (types.LokiClient, error) {
 	switch cfg.ClientConfig.BufferConfig.BufferType {
 	case "dque":
 		return newDque(cfg, logger, newClientFunc)

--- a/pkg/buffer/dque.go
+++ b/pkg/buffer/dque.go
@@ -2,30 +2,33 @@
 This file was copied from the grafana/loki project
 https://github.com/grafana/loki/blob/v1.6.0/cmd/fluent-bit/dque.go
 
-Modifications Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+Modifications Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
 */
 package buffer
 
 import (
 	"fmt"
 	"os"
+	"path"
 	"sync"
 	"time"
 
 	"github.com/gardener/logging/pkg/config"
 	"github.com/gardener/logging/pkg/metrics"
+	"github.com/gardener/logging/pkg/types"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/joncrlsn/dque"
 	"github.com/prometheus/common/model"
 )
 
 type dqueEntry struct {
-	LabelSet  model.LabelSet
-	TimeStamp time.Time
-	Line      string
+	LabelSet model.LabelSet
+	logproto.Entry
+	end bool
 }
 
 func dqueEntryBuilder() interface{} {
@@ -33,15 +36,18 @@ func dqueEntryBuilder() interface{} {
 }
 
 type dqueClient struct {
-	logger log.Logger
-	queue  *dque.DQue
-	loki   client.Client
-	once   sync.Once
-	url    string
+	logger    log.Logger
+	queue     *dque.DQue
+	loki      client.Client
+	once      sync.Once
+	wg        sync.WaitGroup
+	url       string
+	isStooped bool
+	lock      sync.Mutex
 }
 
 // newDque makes a new dque loki client
-func newDque(cfg *config.Config, logger log.Logger, newClientFunc func(cfg client.Config, logger log.Logger) (client.Client, error)) (client.Client, error) {
+func newDque(cfg *config.Config, logger log.Logger, newClientFunc func(cfg client.Config, logger log.Logger) (types.LokiClient, error)) (types.LokiClient, error) {
 	var err error
 
 	q := &dqueClient{
@@ -69,11 +75,14 @@ func newDque(cfg *config.Config, logger log.Logger, newClientFunc func(cfg clien
 		return nil, err
 	}
 
+	q.wg.Add(1)
 	go q.dequeuer()
 	return q, nil
 }
 
 func (c *dqueClient) dequeuer() {
+	defer c.wg.Done()
+
 	for {
 		// Dequeue the next item in the queue
 		entry, err := c.queue.DequeueBlock()
@@ -96,27 +105,59 @@ func (c *dqueClient) dequeuer() {
 			continue
 		}
 
+		if record.end {
+			//TODO: What if the final ending record is malformed here
+			return
+		}
+
 		level.Debug(c.logger).Log("msg", "sending record to Loki", "url", c.url, "record", record.String())
-		if err := c.loki.Handle(record.LabelSet, record.TimeStamp, record.Line); err != nil {
+		if err := c.loki.Handle(record.LabelSet, record.Timestamp, record.Line); err != nil {
 			metrics.Errors.WithLabelValues(metrics.ErrorDequeuerSendRecord).Inc()
 			level.Error(c.logger).Log("msg", fmt.Sprintf("error sending record to Loki %s", c.url), "error", err)
 		}
 		level.Debug(c.logger).Log("msg", "successful sent record to Loki", "host", c.url, "record", record.String())
+
+		c.lock.Lock()
+		if c.isStooped && c.queue.Size() <= 0 {
+			c.lock.Unlock()
+			return
+		}
+		c.lock.Unlock()
 	}
 }
 
 // Stop the client
 func (c *dqueClient) Stop() {
 	c.once.Do(func() {
-		c.queue.Close()
+		if err := c.closeQue(false); err != nil {
+			level.Error(c.logger).Log("msg", "error closing buffered client", "queue", c.queue.Name, "err", err.Error())
+		}
 		c.loki.Stop()
 	})
+}
 
+// Stop the client
+func (c *dqueClient) StopWait() {
+	c.once.Do(func() {
+		if err := c.stopQue(true); err != nil {
+			level.Error(c.logger).Log("msg", "error stopping buffered client", "queue", c.queue.Name, "err", err.Error())
+		}
+		if err := c.closeQue(true); err != nil {
+			level.Error(c.logger).Log("msg", "error closing buffered client", "queue", c.queue.Name, "err", err.Error())
+		}
+		c.loki.Stop()
+	})
 }
 
 // Handle implement EntryHandler; adds a new line to the next batch; send is async.
 func (c *dqueClient) Handle(ls model.LabelSet, t time.Time, s string) error {
-	record := &dqueEntry{ls, t, s}
+	// Here we don't need any synchronization because the worst thing is to
+	// receive some more logs which would be dropped anyway.
+	if c.isStooped {
+		return nil
+	}
+
+	record := &dqueEntry{LabelSet: ls, Entry: logproto.Entry{Timestamp: t, Line: s}}
 	if err := c.queue.Enqueue(record); err != nil {
 		return fmt.Errorf("cannot enqueue record %s: %v", record.String(), err)
 	}
@@ -125,5 +166,36 @@ func (c *dqueClient) Handle(ls model.LabelSet, t time.Time, s string) error {
 }
 
 func (e *dqueEntry) String() string {
-	return fmt.Sprintf("labels: %+v timestamp: %+v line: %+v", e.LabelSet, e.TimeStamp, e.Line)
+	return fmt.Sprintf("labels: %+v timestamp: %+v line: %+v", e.LabelSet, e.Timestamp, e.Line)
+}
+
+func (c *dqueClient) stopQue(wait bool) error {
+	if !wait {
+		return nil
+	}
+	c.lock.Lock()
+	c.isStooped = true
+	// In case the dequeuer is blocked on empty queue.
+	if c.queue.Size() == 0 {
+		c.lock.Unlock() //Nothing to wait for
+		return nil
+	}
+	c.lock.Unlock()
+	//TODO: Make time group waiter
+	c.wg.Wait()
+	return nil
+}
+
+func (c *dqueClient) closeQue(cleanUnderlyingFileBuffer bool) error {
+	if err := c.queue.Close(); err != nil {
+		return fmt.Errorf("cannot close %s buffer: %v", c.queue.Name, err)
+	}
+
+	if cleanUnderlyingFileBuffer {
+		if err := os.RemoveAll(path.Join(c.queue.DirPath, c.queue.Name)); err != nil {
+			return fmt.Errorf("cannot close %s buffer: %v", c.queue.Name, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -15,15 +15,14 @@
 package client
 
 import (
-	"sync"
 	"time"
 
-	"github.com/gardener/logging/pkg/batch"
 	"github.com/gardener/logging/pkg/buffer"
 	"github.com/gardener/logging/pkg/config"
 	"github.com/gardener/logging/pkg/metrics"
+	"github.com/gardener/logging/pkg/types"
+
 	"github.com/go-kit/kit/log"
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/prometheus/common/model"
 )
@@ -33,14 +32,14 @@ const (
 	waitCheckFrequencyDelimiter = 10
 )
 
-type newClientFunc func(cfg client.Config, logger log.Logger) (client.Client, error)
+type newClientFunc func(cfg client.Config, logger log.Logger) (types.LokiClient, error)
 
 // NewClient creates a new client based on the fluentbit configuration.
-func NewClient(cfg *config.Config, logger log.Logger) (client.Client, error) {
+func NewClient(cfg *config.Config, logger log.Logger) (types.LokiClient, error) {
 	var ncf newClientFunc
 
 	if cfg.ClientConfig.SortByTimestamp {
-		ncf = func(c client.Config, logger log.Logger) (client.Client, error) {
+		ncf = func(c client.Config, logger log.Logger) (types.LokiClient, error) {
 			return New(c, cfg.ClientConfig.NumberOfBatchIDs, logger)
 		}
 	} else {
@@ -53,157 +52,6 @@ func NewClient(cfg *config.Config, logger log.Logger) (client.Client, error) {
 	return ncf(cfg.ClientConfig.GrafanaLokiConfig, logger)
 }
 
-type sortedClient struct {
-	logger           log.Logger
-	lokiclient       client.Client
-	batch            *batch.Batch
-	batchWait        time.Duration
-	batchLock        sync.Mutex
-	batchSize        int
-	batchID          uint64
-	numberOfBatchIDs uint64
-	quit             chan struct{}
-	once             sync.Once
-	entries          chan entry
-	wg               sync.WaitGroup
-}
-
-type entry struct {
-	labels model.LabelSet
-	logproto.Entry
-}
-
-// New makes a new Client.
-func New(cfg client.Config, numberOfBatchIds uint64, logger log.Logger) (client.Client, error) {
-	batchWait := cfg.BatchWait
-	cfg.BatchWait = 5 * time.Second
-
-	lokiclient, err := NewPromtailClient(cfg, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	c := &sortedClient{
-		logger:           log.With(logger, "component", "client", "host", cfg.URL.Host),
-		lokiclient:       lokiclient,
-		batchWait:        batchWait,
-		batchSize:        cfg.BatchSize,
-		batchID:          0,
-		numberOfBatchIDs: numberOfBatchIds,
-		batch:            batch.NewBatch(0),
-		quit:             make(chan struct{}),
-		entries:          make(chan entry),
-	}
-
-	c.wg.Add(1)
-	go c.run()
-	return c, nil
-}
-
-func (c *sortedClient) run() {
-	maxWaitCheckFrequency := c.batchWait / waitCheckFrequencyDelimiter
-	if maxWaitCheckFrequency < minWaitCheckFrequency {
-		maxWaitCheckFrequency = minWaitCheckFrequency
-	}
-
-	maxWaitCheck := time.NewTicker(maxWaitCheckFrequency)
-
-	defer func() {
-		if c.batch != nil {
-			c.sendBatch()
-		}
-		c.wg.Done()
-	}()
-
-	for {
-		select {
-		case <-c.quit:
-			return
-
-		case e := <-c.entries:
-
-			// If the batch doesn't exist yet, we create a new one with the entry
-			if c.batch == nil {
-				c.newBatch(e)
-				break
-			}
-
-			// If adding the entry to the batch will increase the size over the max
-			// size allowed, we do send the current batch and then create a new one
-			if c.batch.SizeBytesAfter(e.Line) > c.batchSize {
-				c.sendBatch()
-				c.newBatch(e)
-				break
-			}
-
-			// The max size of the batch isn't reached, so we can add the entry
-			c.addToBatch(e)
-
-		case <-maxWaitCheck.C:
-			// Send batche if max wait time has been reached
-
-			if !c.isBatchWaitExceeded() {
-				continue
-			}
-
-			c.sendBatch()
-		}
-	}
-}
-
-func (c *sortedClient) isBatchWaitExceeded() bool {
-	c.batchLock.Lock()
-	defer c.batchLock.Unlock()
-	return c.batch != nil && c.batch.Age() > c.batchWait
-}
-
-func (c *sortedClient) sendBatch() {
-	c.batchLock.Lock()
-	defer c.batchLock.Unlock()
-
-	if c.batch == nil {
-		return
-	}
-
-	c.batch.Sort()
-	for _, stream := range c.batch.Streams {
-		for _, entry := range stream.Entries {
-			_ = c.lokiclient.Handle(stream.Labels, entry.Timestamp, entry.Line)
-		}
-	}
-	c.batch = nil
-}
-
-func (c *sortedClient) newBatch(e entry) {
-	c.batchLock.Lock()
-	defer c.batchLock.Unlock()
-	if c.batch == nil {
-		c.batchID++
-		c.batch = batch.NewBatch(c.batchID % c.numberOfBatchIDs)
-	}
-
-	c.batch.Add(e.labels.Clone(), e.Timestamp, e.Line)
-}
-
-func (c *sortedClient) addToBatch(e entry) {
-	c.newBatch(e)
-}
-
-// Stop the client.
-func (c *sortedClient) Stop() {
-	c.once.Do(func() { close(c.quit) })
-	c.wg.Wait()
-}
-
-// Handle implement EntryHandler; adds a new line to the next batch; send is async.
-func (c *sortedClient) Handle(ls model.LabelSet, t time.Time, s string) error {
-	c.entries <- entry{ls, logproto.Entry{
-		Timestamp: t,
-		Line:      s,
-	}}
-	return nil
-}
-
 type promtailClientWithForwardedLogsMetricCounter struct {
 	lokiclient client.Client
 	host       string
@@ -211,7 +59,7 @@ type promtailClientWithForwardedLogsMetricCounter struct {
 
 // NewPromtailClient return promtail client which increments the ForwardedLogs counter on
 // successful call of the Handle function
-func NewPromtailClient(cfg client.Config, logger log.Logger) (client.Client, error) {
+func NewPromtailClient(cfg client.Config, logger log.Logger) (types.LokiClient, error) {
 	c, err := client.New(cfg, logger)
 	if err != nil {
 		return nil, err
@@ -232,5 +80,10 @@ func (c *promtailClientWithForwardedLogsMetricCounter) Handle(ls model.LabelSet,
 
 // Stop the client.
 func (c *promtailClientWithForwardedLogsMetricCounter) Stop() {
+	c.lokiclient.Stop()
+}
+
+// StopWait stops the client waiting all saved logs to be sent.
+func (c *promtailClientWithForwardedLogsMetricCounter) StopWait() {
 	c.lokiclient.Stop()
 }

--- a/pkg/client/sorted_client.go
+++ b/pkg/client/sorted_client.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gardener/logging/pkg/batch"
+	"github.com/gardener/logging/pkg/types"
+
+	"github.com/go-kit/kit/log"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/client"
+	"github.com/prometheus/common/model"
+)
+
+type sortedClient struct {
+	logger           log.Logger
+	lokiclient       types.LokiClient
+	batch            *batch.Batch
+	batchWait        time.Duration
+	batchLock        sync.Mutex
+	batchSize        int
+	batchID          uint64
+	numberOfBatchIDs uint64
+	quit             chan struct{}
+	once             sync.Once
+	entries          chan entry
+	wg               sync.WaitGroup
+}
+
+// New makes a new Client.
+func New(cfg client.Config, numberOfBatchIds uint64, logger log.Logger) (types.LokiClient, error) {
+	batchWait := cfg.BatchWait
+	cfg.BatchWait = 5 * time.Second
+
+	lokiclient, err := NewPromtailClient(cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &sortedClient{
+		logger:           log.With(logger, "component", "client", "host", cfg.URL.Host),
+		lokiclient:       lokiclient,
+		batchWait:        batchWait,
+		batchSize:        cfg.BatchSize,
+		batchID:          0,
+		numberOfBatchIDs: numberOfBatchIds,
+		batch:            batch.NewBatch(0),
+		quit:             make(chan struct{}),
+		entries:          make(chan entry),
+	}
+
+	c.wg.Add(1)
+	go c.run()
+	return c, nil
+}
+
+func (c *sortedClient) run() {
+	maxWaitCheckFrequency := c.batchWait / waitCheckFrequencyDelimiter
+	if maxWaitCheckFrequency < minWaitCheckFrequency {
+		maxWaitCheckFrequency = minWaitCheckFrequency
+	}
+
+	maxWaitCheck := time.NewTicker(maxWaitCheckFrequency)
+
+	defer func() {
+		if c.batch != nil {
+			c.sendBatch()
+		}
+		maxWaitCheck.Stop()
+		c.wg.Done()
+	}()
+
+	for {
+		select {
+		case <-c.quit:
+			return
+
+		case e := <-c.entries:
+
+			// If the batch doesn't exist yet, we create a new one with the entry
+			if c.batch == nil {
+				c.newBatch(e)
+				break
+			}
+
+			// If adding the entry to the batch will increase the size over the max
+			// size allowed, we do send the current batch and then create a new one
+			if c.batch.SizeBytesAfter(e.Line) > c.batchSize {
+				c.sendBatch()
+				c.newBatch(e)
+				break
+			}
+
+			// The max size of the batch isn't reached, so we can add the entry
+			c.addToBatch(e)
+
+		case <-maxWaitCheck.C:
+			// Send batche if max wait time has been reached
+
+			if !c.isBatchWaitExceeded() {
+				continue
+			}
+
+			c.sendBatch()
+		}
+	}
+}
+
+func (c *sortedClient) isBatchWaitExceeded() bool {
+	c.batchLock.Lock()
+	defer c.batchLock.Unlock()
+	return c.batch != nil && c.batch.Age() > c.batchWait
+}
+
+func (c *sortedClient) sendBatch() {
+	c.batchLock.Lock()
+	defer c.batchLock.Unlock()
+
+	if c.batch == nil {
+		return
+	}
+
+	c.batch.Sort()
+	for _, stream := range c.batch.Streams {
+		for _, entry := range stream.Entries {
+			_ = c.lokiclient.Handle(stream.Labels, entry.Timestamp, entry.Line)
+		}
+	}
+	c.batch = nil
+}
+
+func (c *sortedClient) newBatch(e entry) {
+	c.batchLock.Lock()
+	defer c.batchLock.Unlock()
+	if c.batch == nil {
+		c.batchID++
+		c.batch = batch.NewBatch(c.batchID % c.numberOfBatchIDs)
+	}
+
+	c.batch.Add(e.labels.Clone(), e.Timestamp, e.Line)
+}
+
+func (c *sortedClient) addToBatch(e entry) {
+	c.newBatch(e)
+}
+
+// Stop the client.
+func (c *sortedClient) Stop() {
+	c.once.Do(func() { close(c.quit) })
+	c.wg.Wait()
+}
+
+func (c *sortedClient) StopWait() {
+	c.once.Do(func() { close(c.quit) })
+	c.wg.Wait()
+}
+
+// Handle implement EntryHandler; adds a new line to the next batch; send is async.
+func (c *sortedClient) Handle(ls model.LabelSet, t time.Time, s string) error {
+	c.entries <- entry{ls, logproto.Entry{
+		Timestamp: t,
+		Line:      s,
+	}}
+	return nil
+}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"time"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/common/model"
+)
+
+type LokiClient interface {
+	Handle(labels model.LabelSet, time time.Time, entry string) error
+	// Stop shut down the client immediately without waiting to send the saved logs
+	Stop()
+	// StopWait stops the client of receiving new logs and waits all saved logs to be sent until shuting down
+	StopWait()
+}
+
+type entry struct {
+	labels model.LabelSet
+	logproto.Entry
+}

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -19,12 +19,13 @@ import (
 	"time"
 
 	client "github.com/gardener/logging/pkg/client"
+	"github.com/gardener/logging/pkg/types"
+
 	"github.com/gardener/logging/pkg/metrics"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/go-kit/kit/log/level"
-	lokiclient "github.com/grafana/loki/pkg/promtail/client"
 )
 
 type deletionTimestamp struct {
@@ -45,7 +46,7 @@ func (ctl *controller) createClientForClusterInDeletionState(cluster *extensions
 	}
 }
 
-func (ctl *controller) getClientForClusterInDeletionState(name string) (lokiclient.Client, bool) {
+func (ctl *controller) getClientForClusterInDeletionState(name string) (types.LokiClient, bool) {
 	ctl.deletedClientsLock.RLock()
 	defer ctl.deletedClientsLock.RUnlock()
 
@@ -87,7 +88,7 @@ func (ctl *controller) cleanExpiredClients() {
 	}
 }
 
-func (ctl *controller) getClientForActiveCluster(name string) (lokiclient.Client, bool) {
+func (ctl *controller) getClientForActiveCluster(name string) (types.LokiClient, bool) {
 	ctl.lock.RLocker().Lock()
 	defer ctl.lock.RLocker().Unlock()
 
@@ -141,7 +142,7 @@ func (ctl *controller) deleteClientForActiveCluster(cluster *extensionsv1alpha1.
 	ctl.lock.Unlock()
 	if ok && client != nil {
 		level.Info(ctl.logger).Log("msg", fmt.Sprintf("Delete client for cluster %v", cluster.Name))
-		client.Stop()
+		client.StopWait()
 	}
 }
 

--- a/pkg/lokiplugin/loki.go
+++ b/pkg/lokiplugin/loki.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gardener/logging/pkg/config"
 	controller "github.com/gardener/logging/pkg/controller"
 	"github.com/gardener/logging/pkg/metrics"
-	lokiclient "github.com/grafana/loki/pkg/promtail/client"
+	"github.com/gardener/logging/pkg/types"
 )
 
 // Loki plugin interface
@@ -32,7 +32,7 @@ type Loki interface {
 
 type loki struct {
 	cfg                             *config.Config
-	defaultClient                   lokiclient.Client
+	defaultClient                   types.LokiClient
 	dynamicHostRegexp               *regexp.Regexp
 	extractKubernetesMetadataRegexp *regexp.Regexp
 	controller                      controller.Controller
@@ -173,7 +173,7 @@ func (l *loki) Close() {
 	}
 }
 
-func (l *loki) getClient(dynamicHosName string) lokiclient.Client {
+func (l *loki) getClient(dynamicHosName string) types.LokiClient {
 	if l.isDynamicHost(dynamicHosName) && l.controller != nil {
 		if c, isStopped := l.controller.GetClient(dynamicHosName); !isStopped {
 			return c
@@ -190,7 +190,7 @@ func (l *loki) isDynamicHost(dynamicHostName string) bool {
 		l.dynamicHostRegexp.Match([]byte(dynamicHostName))
 }
 
-func (l *loki) send(client lokiclient.Client, lbs model.LabelSet, ts time.Time, line string, startOfSendind time.Time) error {
+func (l *loki) send(client types.LokiClient, lbs model.LabelSet, ts time.Time, line string, startOfSendind time.Time) error {
 	elapsedBeforeSend := time.Since(startOfSendind)
 	level.Debug(l.logger).Log("Log-Processing-elapsed ", elapsedBeforeSend.String(), "Stream", lbs)
 

--- a/pkg/lokiplugin/loki_test.go
+++ b/pkg/lokiplugin/loki_test.go
@@ -24,8 +24,7 @@ import (
 	"github.com/weaveworks/common/logging"
 
 	"github.com/gardener/logging/pkg/config"
-
-	lokiclient "github.com/grafana/loki/pkg/promtail/client"
+	"github.com/gardener/logging/pkg/types"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -53,7 +52,8 @@ func (r *recorder) Handle(labels model.LabelSet, time time.Time, e string) error
 
 func (r *recorder) toEntry() *entry { return r.entry }
 
-func (r *recorder) Stop() {}
+func (r *recorder) Stop()     {}
+func (r *recorder) StopWait() {}
 
 type sendRecordArgs struct {
 	cfg     *config.Config
@@ -68,13 +68,14 @@ func (c *fakeLokiClient) Handle(labels model.LabelSet, time time.Time, entry str
 	return nil
 }
 
-func (c *fakeLokiClient) Stop() {}
+func (c *fakeLokiClient) Stop()     {}
+func (c *fakeLokiClient) StopWait() {}
 
 type fakeController struct {
-	clients map[string]lokiclient.Client
+	clients map[string]types.LokiClient
 }
 
-func (ctl *fakeController) GetClient(name string) (lokiclient.Client, bool) {
+func (ctl *fakeController) GetClient(name string) (types.LokiClient, bool) {
 	if client, ok := ctl.clients[name]; ok {
 		return client, false
 	}
@@ -256,7 +257,7 @@ var _ = Describe("Loki plugin", func() {
 
 	Describe("#getClient", func() {
 		fc := fakeController{
-			clients: map[string]lokiclient.Client{
+			clients: map[string]types.LokiClient{
 				"shoot--dev--test1": &fakeLokiClient{},
 				"shoot--dev--test2": &fakeLokiClient{},
 			},

--- a/pkg/types/lokiclient.go
+++ b/pkg/types/lokiclient.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+type LokiClient interface {
+	Handle(labels model.LabelSet, time time.Time, entry string) error
+	// Stop shut down the client immediately without waiting to send the saved logs
+	Stop()
+	// StopWait stops the client of receiving new logs and waits all saved logs to be sent until shuting down
+	StopWait()
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging
/priority critical

**What this PR does / why we need it**:
With this PR when a buffered Loki client is shutdown there are two options for 
1. `Stop()` : This is a forceful stop where the logs in the buffer are not sent and the underlying file is not deleted.
    On the next start, the buffer will be reused if there is a client with the same name.
2. `StopWait()`: With this method, we wait until all the logs from the buffer are sent and then delete the underlying file.
   This is useful when deleting dynamic clients at runtime.
At the moment the behavior of how the plugin will be stopped is not configurable.
If the plugin is shut down then we use forceful Stop and if we delete clients during normal runtime we use the StopWait function.

 **Which issue(s) this PR fixes**:
Fixes [#97](https://github.com/gardener/logging/issues/97) and [#96](https://github.com/gardener/logging/issues/96)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When buffered Loki client is deleted during runtime all of its stored logs are sent before deleting the client.
Also, the underlying file of a buffered Loki client is deleted.
```
