### PR TITLE
implement dynamic tenant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,8 @@ COPY --from=builder /go/src/github.com/gardener/logging/build/curator /curator
 WORKDIR /
 
 ENTRYPOINT [ "/curator" ]
+
+#############      telegraf       #############
+FROM telegraf:1.18.0-alpine AS telegraf
+
+RUN apk add --update bash iptables su-exec sudo && rm -rf /var/cache/apk/*

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ VERSION                               := $(shell cat VERSION)
 REGISTRY                              := eu.gcr.io/gardener-project/gardener
 FLUENT_BIT_TO_LOKI_IMAGE_REPOSITORY   := $(REGISTRY)/fluent-bit-to-loki
 LOKI_CURATOR_IMAGE_REPOSITORY         := $(REGISTRY)/loki-curator
+TELEGRAF_IMAGE_REPOSITORY             := $(REGISTRY)/telegraf-iptables
 IMAGE_TAG                             := $(VERSION)
 
 .PHONY: plugin
@@ -35,6 +36,7 @@ build: plugin curator
 docker-images:
 	@docker build -t $(FLUENT_BIT_TO_LOKI_IMAGE_REPOSITORY):$(IMAGE_TAG) -t $(FLUENT_BIT_TO_LOKI_IMAGE_REPOSITORY):latest -f Dockerfile --target fluent-bit-plugin .
 	@docker build -t $(LOKI_CURATOR_IMAGE_REPOSITORY):$(IMAGE_TAG) -t $(LOKI_CURATOR_IMAGE_REPOSITORY):latest -f Dockerfile --target curator .
+	@docker build -t $(TELEGRAF_IMAGE_REPOSITORY):$(IMAGE_TAG) -t $(TELEGRAF_IMAGE_REPOSITORY):latest -f Dockerfile --target telegraf .
 
 .PHONY: docker-push
 docker-push:
@@ -42,6 +44,8 @@ docker-push:
 	@gcloud docker -- push $(FLUENT_BIT_TO_LOKI_IMAGE_REPOSITORY):$(IMAGE_TAG)
 	@if ! docker images $(LOKI_CURATOR_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(IMAGE_TAG); then echo "$(LOKI_CURATOR_IMAGE_REPOSITORY) version $(IMAGE_TAG) is not yet built. Please run 'make docker-images'"; false; fi
 	@gcloud docker -- push $(LOKI_CURATOR_IMAGE_REPOSITORY):$(IMAGE_TAG)
+	@if ! docker images $(TELEGRAF_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(IMAGE_TAG); then echo "$(TELEGRAF_IMAGE_REPOSITORY) version $(IMAGE_TAG) is not yet built. Please run 'make docker-images'"; false; fi
+	@gcloud docker -- push $(TELEGRAF_IMAGE_REPOSITORY):$(IMAGE_TAG)
 
 .PHONY: revendor
 revendor:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ It also adds additional configurations that aim to improve plugin's performance 
 | SendDeletedClustersLogsToDefaultClient | When cluster is marked for deletion the logs will be send to the default url `URL` | `false`
 | DeletedClientTimeExpiration | The time duration after a client for deleted cluster will be considered for expired | 1 hour
 | CleanExpiredClientsPeriod | Clean the expired clients every `CleanExpiredClientsPeriod` | 24 hours
+| DynamicTenant | When set the value is split on space delimiter to 3 tokens. The first token is the tenant to use, the second one is the field to search for matching. The third is the regex to match token 2. | none
+| RemoveTenantIdWhenSendingToDefaultURL | When `DynamicTenant` is set this flag decide whether to remove the record with dynamic tenant or not when sending them to the default `URL` | true
 ### Labels
 
 Labels are used to [query logs](https://github.com/grafana/loki/blob/v1.5.0/docs/logql.md) `{container_name="nginx", cluster="us-west1"}`, they are usually metadata about the workload producing the log stream (`instance`, `container_name`, `region`, `cluster`, `level`).  In Loki labels are indexed consequently you should be cautious when choosing them (high cardinality label values can have performance drastic impact).
@@ -123,6 +125,7 @@ To configure the Loki output plugin add this section to fluent-bit.conf
     DynamicHostPrefix http://loki.
     DynamicHostSuffix .svc:3100/loki/api/v1/push
     DynamicHostRegex ^shoot-
+    DynamicTenant user gardener user
     MaxRetries 3
     Timeout 10
     MinBackoff 30
@@ -136,41 +139,6 @@ To configure the Loki output plugin add this section to fluent-bit.conf
     TagKey tag
     DropLogEntryWithoutK8sMetadata true
     TenantID operator
-```
-
-```properties
-[Output]
-    Name gardenerloki
-    Match {{ .Values.exposedComponentsTagPrefix }}.kubernetes.*
-    Url http://loki.garden.svc:3100/loki/api/v1/push
-    LogLevel info
-    BatchWait 40
-    BatchSize 30720
-    Labels {test="fluent-bit-go", lang="Golang"}
-    LineFormat json
-    SortByTimestamp true
-    DropSingleKey false
-    AutoKubernetesLabels true
-    LabelSelector gardener.cloud/role:shoot
-    RemoveKeys kubernetes,stream,type,time,tag
-    LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
-    DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
-    DynamicHostPrefix http://loki.
-    DynamicHostSuffix .svc:3100/loki/api/v1/push
-    DynamicHostRegex ^shoot-
-    MaxRetries 3
-    Timeout 10
-    MinBackoff 30
-    Buffer true
-    BufferType dque
-    QueueDir  /fluent-bit/buffers/user
-    QueueSegmentSize 300
-    QueueSync normal
-    QueueName gardener-kubernetes-user
-    FallbackToTagWhenMetadataIsMissing true
-    TagKey tag
-    DropLogEntryWithoutK8sMetadata true
-    TenantID user
 ```
 
 ```properties

--- a/cmd/fluent-bit-loki-plugin/out_loki.go
+++ b/cmd/fluent-bit-loki-plugin/out_loki.go
@@ -135,6 +135,9 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	level.Info(paramLogger).Log("SendDeletedClustersLogsToDefaultClient", fmt.Sprintf("%+v", conf.ControllerConfig.SendDeletedClustersLogsToDefaultClient))
 	level.Info(paramLogger).Log("DeletedClientTimeExpiration", fmt.Sprintf("%+v", conf.ControllerConfig.DeletedClientTimeExpiration))
 	level.Info(paramLogger).Log("CleanExpiredClientsPeriod", fmt.Sprintf("%+v", conf.ControllerConfig.CleanExpiredClientsPeriod))
+	level.Info(paramLogger).Log("DynamicTenant", fmt.Sprintf("%+v", conf.PluginConfig.DynamicTenant.Tenant))
+	level.Info(paramLogger).Log("DynamicField", fmt.Sprintf("%+v", conf.PluginConfig.DynamicTenant.Field))
+	level.Info(paramLogger).Log("DynamicRegex", fmt.Sprintf("%+v", conf.PluginConfig.DynamicTenant.Regex))
 
 	plugin, err := lokiplugin.NewPlugin(informer, conf, logger)
 	if err != nil {

--- a/pkg/buffer/dque.go
+++ b/pkg/buffer/dque.go
@@ -38,7 +38,7 @@ func dqueEntryBuilder() interface{} {
 type dqueClient struct {
 	logger    log.Logger
 	queue     *dque.DQue
-	loki      client.Client
+	loki      types.LokiClient
 	once      sync.Once
 	wg        sync.WaitGroup
 	url       string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -87,3 +87,29 @@ func (c *promtailClientWithForwardedLogsMetricCounter) Stop() {
 func (c *promtailClientWithForwardedLogsMetricCounter) StopWait() {
 	c.lokiclient.Stop()
 }
+
+type removeTenantIdClient struct {
+	lokiclient types.LokiClient
+}
+
+// NewRemoveTenantIdClient return loki client wich removes the __tenant_id__ value fro the label set
+func NewRemoveTenantIdClient(clientToWrap types.LokiClient) types.LokiClient {
+	return &removeTenantIdClient{clientToWrap}
+}
+
+func (c *removeTenantIdClient) Handle(ls model.LabelSet, t time.Time, s string) error {
+	if _, ok := ls[client.ReservedLabelTenantID]; ok {
+		return nil
+	}
+	return c.lokiclient.Handle(ls, t, s)
+}
+
+// Stop the client.
+func (c *removeTenantIdClient) Stop() {
+	c.lokiclient.Stop()
+}
+
+// StopWait stops the client waiting all saved logs to be sent.
+func (c *removeTenantIdClient) StopWait() {
+	c.lokiclient.Stop()
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -61,21 +61,10 @@ var _ = Describe("Config", func() {
 				Expect(err).To(HaveOccurred())
 			} else {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(args.want.PluginConfig.AutoKubernetesLabels).To(Equal(got.PluginConfig.AutoKubernetesLabels))
-				Expect(args.want.ClientConfig.BufferConfig).To(Equal(got.ClientConfig.BufferConfig))
-				Expect(args.want.ClientConfig.GrafanaLokiConfig).To(Equal(got.ClientConfig.GrafanaLokiConfig))
-				Expect(args.want.PluginConfig.DropSingleKey).To(Equal(got.PluginConfig.DropSingleKey))
-				Expect(args.want.PluginConfig.DynamicHostPath).To(Equal(got.PluginConfig.DynamicHostPath))
-				Expect(args.want.ControllerConfig.DynamicHostPrefix).To(Equal(got.ControllerConfig.DynamicHostPrefix))
-				Expect(args.want.PluginConfig.DynamicHostRegex).To(Equal(got.PluginConfig.DynamicHostRegex))
-				Expect(args.want.ControllerConfig.DynamicHostSuffix).To(Equal(got.ControllerConfig.DynamicHostSuffix))
-				Expect(args.want.PluginConfig.LabelKeys).To(Equal(got.PluginConfig.LabelKeys))
-				Expect(args.want.PluginConfig.LabelMap).To(Equal(got.PluginConfig.LabelMap))
-				Expect(args.want.PluginConfig.LineFormat).To(Equal(got.PluginConfig.LineFormat))
-				//Expect(args.want.LogLevel).To(Equal(got.LogLevel))
-				Expect(args.want.PluginConfig.RemoveKeys).To(Equal(got.PluginConfig.RemoveKeys))
-				Expect(args.want.ClientConfig.SortByTimestamp).To(Equal(got.ClientConfig.SortByTimestamp))
-				Expect(args.want.PluginConfig.KubernetesMetadata).To(Equal(got.PluginConfig.KubernetesMetadata))
+				Expect(args.want.ClientConfig).To(Equal(got.ClientConfig))
+				Expect(args.want.ControllerConfig).To(Equal(got.ControllerConfig))
+				Expect(args.want.PluginConfig).To(Equal(got.PluginConfig))
+				Expect(args.want.LogLevel.String()).To(Equal(got.LogLevel.String()))
 			}
 		},
 		Entry("default values", testArgs{
@@ -114,6 +103,12 @@ var _ = Describe("Config", func() {
 							QueueName:        DefaultDqueConfig.QueueName,
 						},
 					},
+					NumberOfBatchIDs: 10,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
 				},
 				LogLevel: infoLogLevel,
 			},
@@ -171,7 +166,13 @@ var _ = Describe("Config", func() {
 							QueueName:        DefaultDqueConfig.QueueName,
 						},
 					},
-					SortByTimestamp: true,
+					NumberOfBatchIDs: 10,
+					SortByTimestamp:  true,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
 				},
 				LogLevel: warnLogLevel,
 			},
@@ -240,6 +241,12 @@ var _ = Describe("Config", func() {
 							QueueName:        DefaultDqueConfig.QueueName,
 						},
 					},
+					NumberOfBatchIDs: 10,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
 				},
 				LogLevel: warnLogLevel,
 			},
@@ -303,10 +310,14 @@ var _ = Describe("Config", func() {
 							QueueName:        DefaultDqueConfig.QueueName,
 						},
 					},
+					NumberOfBatchIDs: 10,
 				},
 				ControllerConfig: ControllerConfig{
-					DynamicHostPrefix: "http://loki.",
-					DynamicHostSuffix: ".svc:3100/loki/api/v1/push",
+					DynamicHostPrefix:           "http://loki.",
+					DynamicHostSuffix:           ".svc:3100/loki/api/v1/push",
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
 				},
 				LogLevel: warnLogLevel,
 			},
@@ -367,6 +378,12 @@ var _ = Describe("Config", func() {
 							QueueName:        "buzz",
 						},
 					},
+					NumberOfBatchIDs: 10,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
 				},
 				LogLevel: warnLogLevel,
 			},
@@ -425,8 +442,13 @@ var _ = Describe("Config", func() {
 							QueueName:        DefaultDqueConfig.QueueName,
 						},
 					},
+					NumberOfBatchIDs: 10,
 				},
-
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
+				},
 				LogLevel: warnLogLevel,
 			},
 			false},
@@ -487,6 +509,12 @@ var _ = Describe("Config", func() {
 							QueueName:        DefaultDqueConfig.QueueName,
 						},
 					},
+					NumberOfBatchIDs: 10,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
 				},
 				LogLevel: warnLogLevel,
 			},
@@ -545,13 +573,182 @@ var _ = Describe("Config", func() {
 							QueueName:        DefaultDqueConfig.QueueName,
 						},
 					},
+					NumberOfBatchIDs: 10,
 				},
-
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
+				},
 				LogLevel: warnLogLevel,
 			},
 			false},
 		),
-
+		Entry("With dynamic tenant values", testArgs{
+			map[string]string{
+				"DynamicTenant": "  user tag user-exposed.kubernetes.*   ",
+			},
+			&Config{
+				PluginConfig: config.PluginConfig{
+					LineFormat: JSONFormat,
+					KubernetesMetadata: KubernetesMetadataExtraction{
+						TagKey:        DefaultKubernetesMetadataTagKey,
+						TagPrefix:     DefaultKubernetesMetadataTagPrefix,
+						TagExpression: DefaultKubernetesMetadataTagExpression,
+					},
+					DropSingleKey:    true,
+					DynamicHostRegex: "*",
+					DynamicTenant: DynamicTenant{
+						Tenant:                                "user",
+						Field:                                 "tag",
+						Regex:                                 "user-exposed.kubernetes.*",
+						RemoveTenantIdWhenSendingToDefaultURL: true,
+					},
+				},
+				ClientConfig: config.ClientConfig{
+					GrafanaLokiConfig: client.Config{
+						URL:            defaultURL,
+						BatchSize:      100 * 1024,
+						BatchWait:      1 * time.Second,
+						ExternalLabels: lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
+						BackoffConfig: util.BackoffConfig{
+							MinBackoff: (1 * time.Second) / 2,
+							MaxBackoff: 300 * time.Second,
+							MaxRetries: 10,
+						},
+						Timeout: 10 * time.Second,
+					},
+					BufferConfig: BufferConfig{
+						Buffer:     false,
+						BufferType: DefaultBufferConfig.BufferType,
+						DqueConfig: DqueConfig{
+							QueueDir:         DefaultDqueConfig.QueueDir,
+							QueueSegmentSize: 500,
+							QueueSync:        false,
+							QueueName:        DefaultDqueConfig.QueueName,
+						},
+					},
+					NumberOfBatchIDs: 10,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
+				},
+				LogLevel: infoLogLevel,
+			},
+			false},
+		),
+		Entry("With only two fields for dynamic tenant values", testArgs{
+			map[string]string{
+				"DynamicTenant": "   user tag    ",
+			},
+			&Config{
+				PluginConfig: config.PluginConfig{
+					LineFormat: JSONFormat,
+					KubernetesMetadata: KubernetesMetadataExtraction{
+						TagKey:        DefaultKubernetesMetadataTagKey,
+						TagPrefix:     DefaultKubernetesMetadataTagPrefix,
+						TagExpression: DefaultKubernetesMetadataTagExpression,
+					},
+					DropSingleKey:    true,
+					DynamicHostRegex: "*",
+					DynamicTenant: DynamicTenant{
+						Tenant:                                "user",
+						Field:                                 "tag",
+						Regex:                                 "user-exposed.kubernetes.*",
+						RemoveTenantIdWhenSendingToDefaultURL: true,
+					},
+				},
+				ClientConfig: config.ClientConfig{
+					GrafanaLokiConfig: client.Config{
+						URL:            defaultURL,
+						BatchSize:      100 * 1024,
+						BatchWait:      1 * time.Second,
+						ExternalLabels: lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
+						BackoffConfig: util.BackoffConfig{
+							MinBackoff: (1 * time.Second) / 2,
+							MaxBackoff: 300 * time.Second,
+							MaxRetries: 10,
+						},
+						Timeout: 10 * time.Second,
+					},
+					BufferConfig: BufferConfig{
+						Buffer:     false,
+						BufferType: DefaultBufferConfig.BufferType,
+						DqueConfig: DqueConfig{
+							QueueDir:         DefaultDqueConfig.QueueDir,
+							QueueSegmentSize: 500,
+							QueueSync:        false,
+							QueueName:        DefaultDqueConfig.QueueName,
+						},
+					},
+					NumberOfBatchIDs: 10,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
+				},
+				LogLevel: infoLogLevel,
+			},
+			true},
+		),
+		Entry("With more than 3 fields for dynamic tenant values", testArgs{
+			map[string]string{
+				"DynamicTenant": "  user tag regex with spaces   ",
+			},
+			&Config{
+				PluginConfig: config.PluginConfig{
+					LineFormat: JSONFormat,
+					KubernetesMetadata: KubernetesMetadataExtraction{
+						TagKey:        DefaultKubernetesMetadataTagKey,
+						TagPrefix:     DefaultKubernetesMetadataTagPrefix,
+						TagExpression: DefaultKubernetesMetadataTagExpression,
+					},
+					DropSingleKey:    true,
+					DynamicHostRegex: "*",
+					DynamicTenant: DynamicTenant{
+						Tenant:                                "user",
+						Field:                                 "tag",
+						Regex:                                 "regex with spaces",
+						RemoveTenantIdWhenSendingToDefaultURL: true,
+					},
+				},
+				ClientConfig: config.ClientConfig{
+					GrafanaLokiConfig: client.Config{
+						URL:            defaultURL,
+						BatchSize:      100 * 1024,
+						BatchWait:      1 * time.Second,
+						ExternalLabels: lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
+						BackoffConfig: util.BackoffConfig{
+							MinBackoff: (1 * time.Second) / 2,
+							MaxBackoff: 300 * time.Second,
+							MaxRetries: 10,
+						},
+						Timeout: 10 * time.Second,
+					},
+					BufferConfig: BufferConfig{
+						Buffer:     false,
+						BufferType: DefaultBufferConfig.BufferType,
+						DqueConfig: DqueConfig{
+							QueueDir:         DefaultDqueConfig.QueueDir,
+							QueueSegmentSize: 500,
+							QueueSync:        false,
+							QueueName:        DefaultDqueConfig.QueueName,
+						},
+					},
+					NumberOfBatchIDs: 10,
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:              60000000000,
+					DeletedClientTimeExpiration: 3600000000000,
+					CleanExpiredClientsPeriod:   86400000000000,
+				},
+				LogLevel: infoLogLevel,
+			},
+			false},
+		),
 		Entry("bad url", testArgs{map[string]string{"URL": "::doh.com"}, nil, true}),
 		Entry("bad BatchWait", testArgs{map[string]string{"BatchWait": "a"}, nil, true}),
 		Entry("bad BatchSize", testArgs{map[string]string{"BatchSize": "a"}, nil, true}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging
/priority normal

**What this PR does / why we need it**:
This PR request gives us an option to add one extra TenantID when a regex matches a value of a specified field from the record.
In this case, if we have `DynamicTenant user tag user-exposed.kubernetes.*` then the plugin will try to find a field `tag`, it will get its value and match the expression `user-exposed.kubernetes.*` against it. If it matches it will add to the  record labels set the dedicated reserve labels `__tenant_id__` with a value of `user`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Additional TenantID can be added via "DynamicTenant" option
```
