### PR TITLE
Integrate Pprof debug package

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It also adds additional configurations that aim to improve plugin's performance 
 | CleanExpiredClientsPeriod | Clean the expired clients every `CleanExpiredClientsPeriod` | 24 hours
 | DynamicTenant | When set the value is split on space delimiter to 3 tokens. The first token is the tenant to use, the second one is the field to search for matching. The third is the regex to match token 2. | none
 | RemoveTenantIdWhenSendingToDefaultURL | When `DynamicTenant` is set this flag decide whether to remove the record with dynamic tenant or not when sending them to the default `URL` | true
+| Pprof | Activating the pprof packeg for debugging purpose | false
 ### Labels
 
 Labels are used to [query logs](https://github.com/grafana/loki/blob/v1.5.0/docs/logql.md) `{container_name="nginx", cluster="us-west1"}`, they are usually metadata about the workload producing the log stream (`instance`, `container_name`, `region`, `cluster`, `level`).  In Loki labels are indexed consequently you should be cautious when choosing them (high cardinality label values can have performance drastic impact).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	ControllerConfig ControllerConfig
 	PluginConfig     PluginConfig
 	LogLevel         logging.Level
+	Pprof            bool
 }
 
 // ClientConfig holds configuration for the clients
@@ -167,6 +168,7 @@ var DefaultDqueConfig = DqueConfig{
 
 // ParseConfig parse a Loki plugin configuration
 func ParseConfig(cfg Getter) (*Config, error) {
+	var err error
 	res := &Config{}
 
 	logLevel := cfg.Get("LogLevel")
@@ -178,6 +180,14 @@ func ParseConfig(cfg Getter) (*Config, error) {
 		return nil, fmt.Errorf("invalid log level: %v", logLevel)
 	}
 	res.LogLevel = level
+
+	pprof := cfg.Get("Pprof")
+	if pprof != "" {
+		res.Pprof, err = strconv.ParseBool(pprof)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for Pprof, error: %v", err)
+		}
+	}
 
 	if err := initClientConfig(cfg, res); err != nil {
 		return nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
With this PR we integrate [pprof](https://pkg.go.dev/runtime/pprof@master) package into the ouput-plugin code.
It could be switched on the Pprof flag.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Pprof profiling can be activated via setting up the `Pprof` flag
```
