### PR TITLE
disable the parallel intput processing

### DIFF
--- a/cmd/fluent-bit-loki-plugin/out_loki.go
+++ b/cmd/fluent-bit-loki-plugin/out_loki.go
@@ -199,12 +199,11 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, _ *C.char) int {
 			timestamp = time.Now()
 		}
 
-		go func(r map[interface{}]interface{}) {
-			err := plugin.SendRecord(r, timestamp)
-			if err != nil {
-				level.Warn(logger).Log("msg", err.Error())
-			}
-		}(record)
+		err := plugin.SendRecord(record, timestamp)
+		if err != nil {
+			level.Warn(logger).Log("msg", err.Error())
+		}
+
 	}
 
 	// Return options:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/area logging
/priority normal

**What this PR does / why we need it**:
With this PR we remove the ability of parallel input processing.
We need this because this feature causes some "Entry Out Of Order" Issues which can be removed by increasing the `batchID` but this will lead to a decrease in the free inodes. This is not a problem by itself because the Loki `curator` will free some but this means that logs younger than 14 will be purged. This contradicts our official retention period.
  
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Disable the parallel input processing of the `fluent-bit-to-loki` output plugin
```
