### PR TITLE
extract __gardener_multitenant_id__ from records

### DIFF
--- a/pkg/lokiplugin/loki.go
+++ b/pkg/lokiplugin/loki.go
@@ -125,6 +125,11 @@ func (l *loki) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 
 	metrics.IncomingLogs.WithLabelValues(host).Inc()
 
+	// Extract __gardener_multitenant_id__ from the record into the labelSet.
+	// And then delete it from the record.
+	extractMultiTenantClientLabel(records, lbs)
+	removeMultiTenantClientLabel(records)
+
 	removeKeys(records, append(l.cfg.PluginConfig.LabelKeys, l.cfg.PluginConfig.RemoveKeys...))
 	if len(records) == 0 {
 		metrics.DroppedLogs.WithLabelValues(host).Inc()

--- a/pkg/lokiplugin/utils.go
+++ b/pkg/lokiplugin/utils.go
@@ -19,6 +19,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
 
+	client "github.com/gardener/logging/pkg/client"
 	"github.com/gardener/logging/pkg/config"
 )
 
@@ -197,6 +198,20 @@ func removeKeys(records map[string]interface{}, keys []string) {
 	for _, k := range keys {
 		delete(records, k)
 	}
+}
+
+func extractMultiTenantClientLabel(records map[string]interface{}, res model.LabelSet) {
+	if value, ok := getRecordValue(client.MultiTenantClientLabel, records); ok {
+		lName := model.LabelName(client.MultiTenantClientLabel)
+		lValue := model.LabelValue(value)
+		if lValue.IsValid() && lName.IsValid() {
+			res[lName] = lValue
+		}
+	}
+}
+
+func removeMultiTenantClientLabel(records map[string]interface{}) {
+	delete(records, client.MultiTenantClientLabel)
 }
 
 func createLine(records map[string]interface{}, f config.Format) (string, error) {


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
With this PR `__gardener_multitenant_id__` is extracted and removed from the record and then added to the label set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`__gardener_multitenant_id__` is extracted and removed from the record and then added to the label set.
```
