### PR TITLE
Aggregate the controller client errors and cloen the label set if needed

### DIFF
--- a/pkg/client/multi_tenant_client.go
+++ b/pkg/client/multi_tenant_client.go
@@ -18,13 +18,13 @@ import (
 	"strings"
 	"time"
 
-	giterrors "github.com/pkg/errors"
-
 	"github.com/gardener/logging/pkg/batch"
 	"github.com/gardener/logging/pkg/types"
 
 	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/prometheus/common/model"
+
+	giterrors "github.com/pkg/errors"
 )
 
 type multiTenantClient struct {

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -17,6 +17,7 @@ package controller
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/prometheus/common/model"
 )
 
 func isShootInHibernation(shoot *gardencorev1beta1.Shoot) bool {
@@ -75,4 +76,11 @@ func getShootState(shoot *gardencorev1beta1.Shoot) clusterState {
 	}
 
 	return clusterStateReady
+}
+
+func copyLabelSet(ls model.LabelSet, deepCopy bool) model.LabelSet {
+	if deepCopy {
+		return ls.Clone()
+	}
+	return ls
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging


**What this PR does / why we need it**:
With this PR the errors generated in the controller client are aggregated instead of immediate return.
This allows logs to be sent to both clients even if there is an error sending the log record to the main client(which is first).
Also, the `LabelSet` map is cloned(if needed) when sent to both clients.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Errors in the controller client are aggragated 
```
```bugfix developer
The `LabelSet` of the log records in the controller client is cloned before being passed to both clients.
```
