### PR TITLE
Include the host name in the label stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It also adds additional configurations that aim to improve plugin's performance 
 | DeletedClientTimeExpiration | The time duration after a client for deleted cluster will be considered for expired | 1 hour
 | DynamicTenant | When set the value is split on space delimiter to 3 tokens. The first token is the tenant to use, the second one is the field to search for matching. The third is the regex to match token 2. | none
 | RemoveTenantIdWhenSendingToDefaultURL | When `DynamicTenant` is set this flag decide whether to remove the record with dynamic tenant or not when sending them to the default `URL` | true
+| HostnameKeyValue | \<hostname-kye\>\<space\>\<hostname-value\> key/value pair adding the hostname into the label stream. When value is omitted the hostname is deduced from os.Hostname() call | nil
 | Pprof | Activating the pprof packeg for debugging purpose | false
 | LabelSetInitCapacity | The initial size of the label set which will be extracted from the records. Reduce map reallocation | 10
 | SendLogsToMainClusterWhenIsInCreationState | Send log to the dynamic cluster when it is in creation state | `true`

--- a/cmd/fluent-bit-loki-plugin/out_loki.go
+++ b/cmd/fluent-bit-loki-plugin/out_loki.go
@@ -150,6 +150,12 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	level.Info(paramLogger).Log("DynamicField", fmt.Sprintf("%+v", conf.PluginConfig.DynamicTenant.Field))
 	level.Info(paramLogger).Log("DynamicRegex", fmt.Sprintf("%+v", conf.PluginConfig.DynamicTenant.Regex))
 	level.Info(paramLogger).Log("Pprof", fmt.Sprintf("%+v", conf.Pprof))
+	if conf.PluginConfig.HostnameKey != nil {
+		level.Info(paramLogger).Log("HostnameKey", fmt.Sprintf("%+v", *conf.PluginConfig.HostnameKey))
+	}
+	if conf.PluginConfig.HostnameValue != nil {
+		level.Info(paramLogger).Log("HostnameValue", fmt.Sprintf("%+v", *conf.PluginConfig.HostnameValue))
+	}
 	level.Info(paramLogger).Log("LabelSetInitCapacity", fmt.Sprintf("%+v", conf.PluginConfig.LabelSetInitCapacity))
 	level.Info(paramLogger).Log("SendLogsToMainClusterWhenIsInCreationState", fmt.Sprintf("%+v", conf.ControllerConfig.MainControllerClientConfig.SendLogsWhenIsInCreationState))
 	level.Info(paramLogger).Log("SendLogsToMainClusterWhenIsInReadyState", fmt.Sprintf("%+v", conf.ControllerConfig.MainControllerClientConfig.SendLogsWhenIsInReadyState))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,6 +136,10 @@ type PluginConfig struct {
 	DynamicTenant DynamicTenant
 	//LabelSetInitCapacity the initial capacity of the labelset stream
 	LabelSetInitCapacity int
+	//HostnameKey is the key name of the hostname key/value pair
+	HostnameKey *string
+	//HostnameValue is the value name of the hostname key/value pair
+	HostnameValue *string
 }
 
 // BufferConfig contains the buffer settings
@@ -559,7 +563,21 @@ func initPluginConfig(cfg Getter, res *Config) error {
 			res.PluginConfig.LabelSetInitCapacity = labelSetInitCapacityValue
 		}
 	} else {
-		res.PluginConfig.LabelSetInitCapacity = 10
+		res.PluginConfig.LabelSetInitCapacity = 12
+	}
+
+	hostnameKeyValue := cfg.Get("HostnameKeyValue")
+	if hostnameKeyValue != "" {
+		hostnameKeyValueTokens := strings.SplitN(hostnameKeyValue, " ", 2)
+		switch len(hostnameKeyValueTokens) {
+		case 1:
+			res.PluginConfig.HostnameKey = &hostnameKeyValueTokens[0]
+		case 2:
+			res.PluginConfig.HostnameKey = &hostnameKeyValueTokens[0]
+			res.PluginConfig.HostnameValue = &hostnameKeyValueTokens[1]
+		default:
+			return fmt.Errorf("failed to parse HostnameKeyValue. Should consist of <hostname-key>\" \"<optional hostname-value>\". Found %d elements", len(hostnameKeyValueTokens))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
This PR adds the option to specify the hostname in the label stream of each log.
Adding `HostnameKeyValue`   `hostname ${NODE_NAME}` in the configuration will insert `hostname` `the name of the node` into the label stream.
**Which issue(s) this PR fixes**:
Fixes [#117](https://github.com/gardener/logging/issues/117)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The hostname can be inserted into the log label stream via configuration.
```
