### PR TITLE
update the alpine and telegraf images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN  make build
 
 #############  fluent-bit-plugin #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.3 AS fluent-bit-plugin
+FROM alpine:3.15.4 AS fluent-bit-plugin
 
 COPY --from=builder /go/src/github.com/gardener/logging/build /source/plugins
 
@@ -26,6 +26,6 @@ EXPOSE 2718
 ENTRYPOINT [ "/curator" ]
 
 #############      telegraf       #############
-FROM telegraf:1.18.0-alpine AS telegraf
+FROM telegraf:1.22.3-alpine AS telegraf
 
 RUN apk add --update bash iptables su-exec sudo && rm -rf /var/cache/apk/*


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
The base image for the `fluent-bit-to-loki` plugin is updated from alpine 3.12.3 to 3.15.4.
The base image for `telegraf-iptables` is updated from 1.18.0-alpine to telegraf:1.22.3-alpine. 
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The base image for the `fluent-bit-to-loki` plugin is updated from alpine 3.12.3 to 3.15.4.
```
```other operator
The base image for `telegraf-iptables` is updated from 1.18.0-alpine to telegraf:1.22.3-alpine. 
```