### PR TITLE
Make the origin value starting with lower case(shoot/seed)

### DIFF
--- a/pkg/events/events_logger.go
+++ b/pkg/events/events_logger.go
@@ -51,14 +51,14 @@ type GardenerEventWatcherConfig struct {
 func (e *GardenerEventWatcherConfig) New() *GardenerEventWatcher {
 	_ = e.SeedKubeInformerFactory.InformerFor(&v1.Event{},
 		NewEventInformerFuncForNamespace(
-			"Seed",
+			"seed",
 			e.SeedEventWatcherConfig.Namespace,
 		),
 	)
 
 	_ = e.ShootKubeInformerFactory.InformerFor(&v1.Event{},
 		NewEventInformerFuncForNamespace(
-			"Shoot",
+			"shoot",
 			e.ShootEventWatcherConfig.Namespace,
 		),
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enchacement
/area logging

**What this PR does / why we need it**:
Make the `origin` label value of the event starting with lower case.
This will make the search by origin more convenient because users most often use lower case typing `shoot/seed` instead `Shoot/Seed`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The value of the `origin` label starts with lower case.
```
