### PR TITLE
Build Multi-Arch Images 📦

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,10 @@ logging:
         preprocess:
           'inject-commit-hash'
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           fluent-bit-to-loki:
             registry: 'gcr-readwrite'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.18 AS builder
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
 
-RUN  make build
+RUN make build
 
 #############  fluent-bit-plugin #############
 FROM alpine:3.15.4 AS fluent-bit-plugin

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,11 @@ EXPOSE 2718
 ENTRYPOINT [ "/curator" ]
 
 #############      telegraf       #############
-FROM telegraf:1.22.3-alpine AS telegraf
+FROM telegraf:1.22.3 AS telegraf
 
-RUN apk add --update bash iptables su-exec sudo && rm -rf /var/cache/apk/*
+RUN apt update
+RUN apt install -y iptables
+RUN apt clean
 
 #############      eventlogger       #############
 FROM gcr.io/distroless/static:nonroot AS event-logger

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ plugin:
 
 .PHONY: curator
 curator:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
+	CGO_ENABLED=0 GO111MODULE=on \
 	  go build -mod=vendor -o build/curator ./cmd/loki-curator
 
 .PHONY: event-logger
 event-logger:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
+	CGO_ENABLED=0 GO111MODULE=on \
 	  go build -mod=vendor -o build/event-logger ./cmd/event-logger
 
 .PHONY: build


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging
/priority normal

**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images with support for `linux/amd64` and `linux/arm64`.

**Which issue(s) this PR fixes**:
Fixes parts of https://github.com/gardener/gardener/issues/6258

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Published docker images for Logging are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
