### PR TITLE
Update base image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.18 AS plugin-builder
+FROM golang:1.18.5 AS plugin-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -8,7 +8,7 @@ ARG TARGETARCH
 RUN make plugin GOARCH=$TARGETARCH
 
 #############  fluent-bit-plugin #############
-FROM alpine:3.15.4 AS fluent-bit-plugin
+FROM alpine:3.16.1 AS fluent-bit-plugin
 
 COPY --from=plugin-builder /go/src/github.com/gardener/logging/build /source/plugins
 
@@ -17,7 +17,7 @@ WORKDIR /
 ENTRYPOINT ["cp","/source/plugins/.","/plugins", "-fr"]
 
 #############      image-builder       #############
-FROM golang:1.18 AS image-builder
+FROM golang:1.18.5 AS image-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -46,7 +46,7 @@ WORKDIR /
 ENTRYPOINT [ "/event-logger" ]
 
 #############      telegraf       #############
-FROM telegraf:1.22.3 AS telegraf
+FROM telegraf:1.23.3 AS telegraf
 
 RUN apt update
 RUN apt install -y iptables


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind technical-debt
/area logging

**What this PR does / why we need it**:
Update base image version of:
golang:1.18 -> 1.18.5.
alpine:3.15.4 -> 3.16.1. 
elegraf:1.22.3 -> 1.23.3

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update base image version of golang:1.18 -> 1.18.5, alpine:3.15.4 -> 3.16.1, telegraf:1.22.3 -> 1.23.3
```
