### PR TITLE
Fix some issues with the event logger.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Ignore everything
+**
+
+# Exclude folders relevant for build
+!.git
+!.dockerignore
+!cmd/
+!build/
+!hack/
+!pkg/
+!vendor/
+!.golangci.yaml
+!go.mod
+!go.sum
+!Makefile
+!VERSION

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PACKAGE_PATH="${1:-k8s.io/component-base}"
+VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
+PROGRAM_NAME="${3:-Gardener}"
+VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
+VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
+
+MAJOR_VERSION=""
+MINOR_VERSION=""
+
+if [[ "${VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+  MAJOR_VERSION=${BASH_REMATCH[1]}
+  MINOR_VERSION=${BASH_REMATCH[2]}
+  if [[ -n "${BASH_REMATCH[4]}" ]]; then
+    MINOR_VERSION+="+"
+  fi
+fi
+
+# .dockerignore ignores all files unrelevant for build (e.g. docs) to only copy relevant source files to the build
+# container. Hence, git will always detect a dirty work tree when building in a container (many deleted files).
+# This command filters out all deleted files that are ignored by .dockerignore to only detect changes to relevant files
+# as a dirty work tree.
+# Additionally, it filters out changes to the `VERSION` file, as this is currently the only way to inject the
+# version-to-build in our pipelines (see https://github.com/gardener/cc-utils/issues/431).
+TREE_STATE="$([ -z "$(git status --porcelain 2>/dev/null | grep -vf <(git ls-files -o --deleted --ignored --exclude-from=.dockerignore) -e 'VERSION')" ] && echo clean || echo dirty)"
+
+echo "-X $PACKAGE_PATH/version.gitMajor=$MAJOR_VERSION
+      -X $PACKAGE_PATH/version.gitMinor=$MINOR_VERSION
+      -X $PACKAGE_PATH/version.gitVersion=$VERSION
+      -X $PACKAGE_PATH/version.gitTreeState=$TREE_STATE
+      -X $PACKAGE_PATH/version.gitCommit=$(git rev-parse --verify HEAD)
+      -X $PACKAGE_PATH/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')
+      -X $PACKAGE_PATH/version/verflag.programName=$PROGRAM_NAME"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "> Install"
+
+LD_FLAGS="${LD_FLAGS:-$($(dirname $0)/get-build-ld-flags.sh)}"
+
+CGO_ENABLED=0 GOOS=$(go env GOOS ) GOARCH=$(go env GOARCH) GO111MODULE=on \
+  go install -mod=vendor -ldflags "$LD_FLAGS" \
+  $@

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+)
+
+type EventWatcherConfig struct {
+	Kubeconfig string //Do I need this field?
+	Namespace  string
+}
+
+type GardenerEventWatcherConfig struct {
+	SeedEventWatcherConfig   EventWatcherConfig
+	SeedKubeInformerFactory  kubeinformers.SharedInformerFactory
+	ShootEventWatcherConfig  EventWatcherConfig
+	ShootKubeInformerFactory kubeinformers.SharedInformerFactory
+}
+
+type GardenerEventWatcher struct {
+	SeedKubeInformerFactory  kubeinformers.SharedInformerFactory
+	ShootKubeInformerFactory kubeinformers.SharedInformerFactory
+}
+
+// Options has all the context and parameters needed to run a Gardener Event Logger.
+type Options struct {
+	Kubeconfig string
+	Namespace  string
+}
+
+type SeedOptions struct {
+	Options
+}
+
+type ShootOptions struct {
+	Options
+}
+
+type event struct {
+	Origin         string      `json:"origin" protobuf:"bytes,9,name=origin"`
+	Type           string      `json:"type,omitempty" protobuf:"bytes,9,opt,name=type"`
+	Count          int32       `json:"count,omitempty" protobuf:"varint,8,opt,name=count"`
+	FirstTimestamp metav1.Time `json:"firstTimestamp,omitempty" protobuf:"bytes,6,opt,name=firstTimestamp"`
+	LastTimestamp  metav1.Time `json:"lastTimestamp,omitempty" protobuf:"bytes,7,opt,name=lastTimestamp"`
+	Reason         string      `json:"reason,omitempty" protobuf:"bytes,3,opt,name=reason"`
+	Object         string      `json:"object" protobuf:"bytes,2,opt,name=object"`
+	Message        string      `json:"_entry,omitempty" protobuf:"bytes,4,opt,name=_entry"`
+	Source         string      `json:"source,omitempty" protobuf:"bytes,5,opt,name=source"`
+	SourceHost     string      `json:"sourceHost,omitempty" protobuf:"bytes,2,opt,name=sourceHost"`
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
With this PR the following features are added:
- Events older than 5 seconds are omitted. Thus when the event logger is restarted it will repeat only the logs few recent events.
- The version of the event logger is well formatted and accurate.

**Which issue(s) this PR fixes**:
Fixes [#131](https://github.com/gardener/logging/issues/131)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Events older than 5 seconds are omitted. Thus when the event logger is restarted it will repeat only the logs few recent events.
```
```bugfix operator
The version of the event logger is well formatted and accurate.
```