### PR TITLE
Pack splited shoots logs sent to the central Loki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=plugin-builder /go/src/github.com/gardener/logging/build /source/plu
 
 WORKDIR /
 
-ENTRYPOINT ["cp","/source/plugins/.","/plugins", "-fr"]
+CMD cp /source/plugins/. /plugins -fr
 
 #############      image-builder       #############
 FROM golang:1.18.5 AS image-builder

--- a/cmd/fluent-bit-loki-plugin/out_loki.go
+++ b/cmd/fluent-bit-loki-plugin/out_loki.go
@@ -156,6 +156,9 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	if conf.PluginConfig.HostnameValue != nil {
 		level.Info(paramLogger).Log("HostnameValue", fmt.Sprintf("%+v", *conf.PluginConfig.HostnameValue))
 	}
+	if conf.PluginConfig.PreservedLabels != nil {
+		level.Info(paramLogger).Log("PreservedLabels", fmt.Sprintf("%+v", conf.PluginConfig.PreservedLabels))
+	}
 	level.Info(paramLogger).Log("LabelSetInitCapacity", fmt.Sprintf("%+v", conf.PluginConfig.LabelSetInitCapacity))
 	level.Info(paramLogger).Log("SendLogsToMainClusterWhenIsInCreationState", fmt.Sprintf("%+v", conf.ControllerConfig.MainControllerClientConfig.SendLogsWhenIsInCreationState))
 	level.Info(paramLogger).Log("SendLogsToMainClusterWhenIsInReadyState", fmt.Sprintf("%+v", conf.ControllerConfig.MainControllerClientConfig.SendLogsWhenIsInReadyState))

--- a/pkg/buffer/buffer_test.go
+++ b/pkg/buffer/buffer_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/promtail/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
@@ -33,14 +32,14 @@ import (
 var _ = Describe("Buffer", func() {
 	var infoLogLevel logging.Level
 	_ = infoLogLevel.Set("info")
-	var conf *config.Config
+	var conf config.Config
 
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	logger = level.NewFilter(logger, infoLogLevel.Gokit)
 
 	Describe("NewBuffer", func() {
 		BeforeEach(func() {
-			conf = &config.Config{
+			conf = config.Config{
 				ClientConfig: config.ClientConfig{
 					BufferConfig: config.BufferConfig{
 						Buffer:     false,
@@ -80,7 +79,7 @@ var _ = Describe("Buffer", func() {
 
 		BeforeEach(func() {
 			var err error
-			conf = &config.Config{
+			conf = config.Config{
 				ClientConfig: config.ClientConfig{
 					BufferConfig: config.BufferConfig{
 						Buffer:     false,
@@ -94,7 +93,7 @@ var _ = Describe("Buffer", func() {
 					},
 				},
 			}
-			lokiclient, err = newDque(conf, logger, newFakeLokiClient)
+			lokiclient, err = NewDque(conf, logger, newFakeLokiClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(lokiclient).ToNot(BeNil())
 		})
@@ -151,7 +150,7 @@ type fakeLokiclient struct {
 	sentLogs []logEntry
 }
 
-func newFakeLokiClient(c client.Config, logger log.Logger) (types.LokiClient, error) {
+func newFakeLokiClient(c config.Config, logger log.Logger) (types.LokiClient, error) {
 	return &fakeLokiclient{}, nil
 }
 

--- a/pkg/buffer/dque.go
+++ b/pkg/buffer/dque.go
@@ -20,7 +20,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/joncrlsn/dque"
 	"github.com/prometheus/common/model"
 )
@@ -46,8 +45,8 @@ type dqueClient struct {
 	lock      sync.Mutex
 }
 
-// newDque makes a new dque loki client
-func newDque(cfg *config.Config, logger log.Logger, newClientFunc func(cfg client.Config, logger log.Logger) (types.LokiClient, error)) (types.LokiClient, error) {
+// NewDque makes a new dque loki client
+func NewDque(cfg config.Config, logger log.Logger, newClientFunc func(cfg config.Config, logger log.Logger) (types.LokiClient, error)) (types.LokiClient, error) {
 	var err error
 
 	q := &dqueClient{
@@ -70,7 +69,7 @@ func newDque(cfg *config.Config, logger log.Logger, newClientFunc func(cfg clien
 		_ = q.queue.TurboOn()
 	}
 
-	q.loki, err = newClientFunc(cfg.ClientConfig.GrafanaLokiConfig, logger)
+	q.loki, err = newClientFunc(cfg, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/buffer_client.go
+++ b/pkg/client/buffer_client.go
@@ -2,24 +2,25 @@
 This file was copied from the grafana/loki project
 https://github.com/grafana/loki/blob/v1.6.0/cmd/fluent-bit/buffer.go
 
-Modifications Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+Modifications Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved.
 */
-package buffer
+package client
 
 import (
 	"fmt"
 
+	"github.com/gardener/logging/pkg/buffer"
 	"github.com/gardener/logging/pkg/config"
 	"github.com/gardener/logging/pkg/types"
 
 	"github.com/go-kit/kit/log"
 )
 
-// NewBuffer makes a new buffered Client.
-func NewBuffer(cfg config.Config, logger log.Logger, newClientFunc func(cfg config.Config, logger log.Logger) (types.LokiClient, error)) (types.LokiClient, error) {
+// NewBufferDecorator makes a new buffered Client.
+func NewBufferDecorator(cfg config.Config, newClientFunc NewLokiClientFunc, logger log.Logger) (types.LokiClient, error) {
 	switch cfg.ClientConfig.BufferConfig.BufferType {
 	case "dque":
-		return NewDque(cfg, logger, newClientFunc)
+		return buffer.NewDque(cfg, logger, newClientFunc)
 	default:
 		return nil, fmt.Errorf("failed to parse bufferType: %s", cfg.ClientConfig.BufferConfig.BufferType)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Client", func() {
 	defaultURL, _ := parseURL("http://localhost:3100/loki/api/v1/push")
 	var infoLogLevel logging.Level
 	_ = infoLogLevel.Set("info")
-	conf := &config.Config{
+	conf := config.Config{
 		ClientConfig: config.ClientConfig{
 			GrafanaLokiConfig: client.Config{
 				URL:            defaultURL,
@@ -88,7 +88,7 @@ var _ = Describe("Client", func() {
 
 	Describe("NewClient", func() {
 		It("should create a client", func() {
-			c, err := NewClient(conf, logger)
+			c, err := NewClient(conf, logger, Options{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
 		})

--- a/pkg/client/metric_promtail_client.go
+++ b/pkg/client/metric_promtail_client.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"time"
+
+	"github.com/gardener/logging/pkg/metrics"
+	"github.com/gardener/logging/pkg/types"
+
+	"github.com/go-kit/kit/log"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/promtail/client"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+)
+
+type promtailClientWithForwardedLogsMetricCounter struct {
+	lokiclient client.Client
+	host       string
+}
+
+// NewPromtailClient return LokiClient which wraps the original Promtail client.
+// It increments the ForwardedLogs counter on successful call of the Handle function.
+// !!!This must be the bottom wrapper!!!
+func NewPromtailClient(cfg client.Config, logger log.Logger) (types.LokiClient, error) {
+	c, err := client.New(prometheus.DefaultRegisterer, cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+	return &promtailClientWithForwardedLogsMetricCounter{
+		lokiclient: c,
+		host:       cfg.URL.Hostname(),
+	}, nil
+}
+
+func (c *promtailClientWithForwardedLogsMetricCounter) Handle(ls model.LabelSet, t time.Time, s string) error {
+	c.lokiclient.Chan() <- api.Entry{Labels: ls, Entry: logproto.Entry{Timestamp: t, Line: s}}
+	metrics.ForwardedLogs.WithLabelValues(c.host).Inc()
+	return nil
+}
+
+// Stop the client.
+func (c *promtailClientWithForwardedLogsMetricCounter) Stop() {
+	c.lokiclient.Stop()
+}
+
+// StopWait stops the client waiting all saved logs to be sent.
+func (c *promtailClientWithForwardedLogsMetricCounter) StopWait() {
+	c.lokiclient.Stop()
+}

--- a/pkg/client/pack_client.go
+++ b/pkg/client/pack_client.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/gardener/logging/pkg/config"
+	"github.com/gardener/logging/pkg/types"
+	"github.com/go-kit/kit/log"
+
+	"github.com/prometheus/common/model"
+)
+
+type packClient struct {
+	lokiClient     types.LokiClient
+	excludedLabels model.LabelSet
+}
+
+// NewPackClient return loki client which pack all the labels except the explicitly excluded ones and forward them the the wrapped client.
+func NewPackClientDecorator(cfg config.Config, newClient NewLokiClientFunc, logger log.Logger) (types.LokiClient, error) {
+	client, err := newLokiClient(cfg, newClient, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return &packClient{
+		lokiClient:     client,
+		excludedLabels: cfg.PluginConfig.PreservedLabels.Clone(),
+	}, nil
+}
+
+//This function can modify the label set so avoid concurrent use of it.
+func (c *packClient) Handle(ls model.LabelSet, t time.Time, s string) error {
+	if c.checkIfLabelSetContainsExcludedLabels(ls) {
+		log := make(map[string]string, len(ls))
+
+		for key, value := range ls {
+			if _, ok := c.excludedLabels[key]; !ok && !strings.HasPrefix(string(key), "__") {
+				log[string(key)] = string(value)
+				delete(ls, key)
+			}
+		}
+		log["_entry"] = s
+		log["time"] = t.String()
+
+		jsonStr, err := json.Marshal(log)
+		if err != nil {
+			return err
+		}
+
+		s = string(jsonStr)
+		// It is important to set the log time as now in order to avoid "Entry Out Of Order".
+		// When couple of Loki streams are packed as one nothing guaranties that the logs will be time sequential.
+		// TODO: (vlvasilev) If one day we upgrade Loki above 2.2.1 to a version when logs are not obligated to be
+		// time sequential make this timestamp rewrite optional.
+		t = time.Now()
+	}
+
+	return c.lokiClient.Handle(ls, t, s)
+}
+
+// Stop the client.
+func (c *packClient) Stop() {
+	c.lokiClient.Stop()
+}
+
+// StopWait stops the client waiting all saved logs to be sent.
+func (c *packClient) StopWait() {
+	c.lokiClient.StopWait()
+}
+
+func (c *packClient) checkIfLabelSetContainsExcludedLabels(ls model.LabelSet) bool {
+	for key := range c.excludedLabels {
+		if _, ok := ls[key]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/client/pack_client_test.go
+++ b/pkg/client/pack_client_test.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/gardener/logging/pkg/client"
+	"github.com/gardener/logging/pkg/config"
+	"github.com/gardener/logging/pkg/types"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/weaveworks/common/logging"
+
+	"github.com/grafana/loki/pkg/logproto"
+	. "github.com/onsi/ginkgo"
+	ginkotable "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
+)
+
+var _ = Describe("Pack Client", func() {
+
+	var (
+		fakeClient *client.FakeLokiClient
+		//packClient      types.LokiClient
+		preservedLabels = model.LabelSet{
+			"origin":    "",
+			"namespace": "",
+		}
+		incomingLabelSet = model.LabelSet{
+			"namespace":      "foo",
+			"origin":         "seed",
+			"pod_name":       "foo",
+			"container_name": "bar",
+		}
+		timeNow, timeNowPlus1Sec, timeNowPlus2Seconds = time.Now(), time.Now().Add(1 * time.Second), time.Now().Add(2 * time.Second)
+		firstLog, secondLog, thirdLog                 = "I am the first log.", "And I am the second one", "I guess bronze is good, too"
+		cfg                                           config.Config
+		newLokiClientFunc                             = func(_ config.Config, _ log.Logger) (types.LokiClient, error) {
+			return fakeClient, nil
+		}
+
+		logger log.Logger
+	)
+
+	BeforeEach(func() {
+		fakeClient = &client.FakeLokiClient{}
+		cfg = config.Config{}
+
+		var infoLogLevel logging.Level
+		_ = infoLogLevel.Set("info")
+		logger = level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), infoLogLevel.Gokit)
+
+	})
+
+	type handleArgs struct {
+		preservedLabels model.LabelSet
+		incomingEntries []client.Entry
+		wantedEntries   []client.Entry
+	}
+
+	ginkotable.DescribeTable("#Handle", func(args handleArgs) {
+		cfg.PluginConfig.PreservedLabels = args.preservedLabels
+		packClient, err := client.NewPackClientDecorator(cfg, newLokiClientFunc, logger)
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, entry := range args.incomingEntries {
+			err := packClient.Handle(entry.Labels, entry.Timestamp, entry.Line)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		Expect(len(fakeClient.Entries)).To(Equal(len(args.wantedEntries)))
+		for idx, entry := range fakeClient.Entries {
+			entry.Timestamp.After(args.wantedEntries[idx].Timestamp)
+			Expect((entry.Labels)).To(Equal(args.wantedEntries[idx].Labels))
+			Expect((entry.Line)).To(Equal(args.wantedEntries[idx].Line))
+		}
+	},
+		ginkotable.Entry("Handle record without preserved labels", handleArgs{
+			preservedLabels: model.LabelSet{},
+			incomingEntries: []client.Entry{
+				{
+					Labels: incomingLabelSet.Clone(),
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      firstLog,
+					},
+				},
+			},
+			wantedEntries: []client.Entry{
+				{
+					Labels: incomingLabelSet.Clone(),
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      firstLog,
+					},
+				},
+			},
+		}),
+		ginkotable.Entry("Handle one record which contains only one reserved label", handleArgs{
+			preservedLabels: preservedLabels,
+			incomingEntries: []client.Entry{
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      firstLog,
+					},
+				},
+			},
+			wantedEntries: []client.Entry{
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      packLog(nil, timeNow, firstLog),
+					},
+				},
+			},
+		}),
+		ginkotable.Entry("Handle two record which contains only the reserved label", handleArgs{
+			preservedLabels: preservedLabels,
+			incomingEntries: []client.Entry{
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+						"origin":    "seed",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      firstLog,
+					},
+				},
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+						"origin":    "seed",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNowPlus1Sec,
+						Line:      secondLog,
+					},
+				},
+			},
+			wantedEntries: []client.Entry{
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+						"origin":    "seed",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      packLog(nil, timeNow, firstLog),
+					},
+				},
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+						"origin":    "seed",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNowPlus1Sec,
+						Line:      packLog(nil, timeNowPlus1Sec, secondLog),
+					},
+				},
+			},
+		}),
+		ginkotable.Entry("Handle three record which contains various label", handleArgs{
+			preservedLabels: preservedLabels,
+			incomingEntries: []client.Entry{
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+						"origin":    "seed",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      firstLog,
+					},
+				},
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNowPlus1Sec,
+						Line:      secondLog,
+					},
+				},
+				{
+					Labels: incomingLabelSet.Clone(),
+					Entry: logproto.Entry{
+						Timestamp: timeNowPlus2Seconds,
+						Line:      thirdLog,
+					},
+				},
+			},
+			wantedEntries: []client.Entry{
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+						"origin":    "seed",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNow,
+						Line:      packLog(nil, timeNow, firstLog),
+					},
+				},
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNowPlus1Sec,
+						Line:      packLog(nil, timeNowPlus1Sec, secondLog),
+					},
+				},
+				{
+					Labels: model.LabelSet{
+						"namespace": "foo",
+						"origin":    "seed",
+					},
+					Entry: logproto.Entry{
+						Timestamp: timeNowPlus2Seconds,
+						Line: packLog(model.LabelSet{
+							"pod_name":       "foo",
+							"container_name": "bar",
+						}, timeNowPlus2Seconds, thirdLog),
+					},
+				},
+			},
+		}),
+	)
+
+	Describe("#Stop", func() {
+		It("should stop", func() {
+			packClient, err := client.NewPackClientDecorator(cfg, newLokiClientFunc, logger)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fakeClient.IsGracefullyStopped).To(BeFalse())
+			Expect(fakeClient.IsStopped).To(BeFalse())
+
+			packClient.Stop()
+			Expect(fakeClient.IsGracefullyStopped).To(BeFalse())
+			Expect(fakeClient.IsStopped).To(BeTrue())
+		})
+	})
+
+	Describe("#StopWait", func() {
+		It("should stop", func() {
+			packClient, err := client.NewPackClientDecorator(cfg, newLokiClientFunc, logger)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fakeClient.IsGracefullyStopped).To(BeFalse())
+			Expect(fakeClient.IsStopped).To(BeFalse())
+
+			packClient.StopWait()
+			Expect(fakeClient.IsGracefullyStopped).To(BeTrue())
+			Expect(fakeClient.IsStopped).To(BeFalse())
+		})
+	})
+
+})
+
+func packLog(ls model.LabelSet, t time.Time, logLine string) string {
+	log := make(map[string]string, len(ls))
+	log["_entry"] = logLine
+	log["time"] = t.String()
+	for key, value := range ls {
+		log[string(key)] = string(value)
+	}
+	jsonStr, err := json.Marshal(log)
+	if err != nil {
+		return err.Error()
+	}
+	return string(jsonStr)
+}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -17,11 +17,17 @@ package client
 import (
 	"time"
 
+	"github.com/gardener/logging/pkg/config"
+	"github.com/gardener/logging/pkg/types"
+
+	"github.com/go-kit/kit/log"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
 )
 
+// LokiClient represents an instance which sends logs to Loki ingester
 type LokiClient interface {
+	// Handle processes logs and then sends them to Loki ingester
 	Handle(labels model.LabelSet, time time.Time, entry string) error
 	// Stop shut down the client immediately without waiting to send the saved logs
 	Stop()
@@ -33,3 +39,9 @@ type Entry struct {
 	Labels model.LabelSet
 	logproto.Entry
 }
+
+// NewLokiClientFunc returns a LokiClient on success.
+type NewLokiClientFunc func(cfg config.Config, logger log.Logger) (types.LokiClient, error)
+
+// NewLokiClientDecoratorFunc return LokiClient which wraps another LokiClient
+type NewLokiClientDecoratorFunc func(cfg config.Config, client LokiClient, logger log.Logger) (types.LokiClient, error)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,36 +110,38 @@ type ControllerClientConfiguration struct {
 	SendLogsWhenIsInMigrationState   bool
 }
 
-// PluginConfig contains the configuration mostly related to the Loki plugin
+// PluginConfig contains the configuration mostly related to the Loki plugin.
 type PluginConfig struct {
-	// AutoKubernetesLabels extact all key/values from the kubernetes field
+	// AutoKubernetesLabels extact all key/values from the kubernetes field.
 	AutoKubernetesLabels bool
-	// RemoveKeys specify removing keys
+	// RemoveKeys specify removing keys.
 	RemoveKeys []string
-	// LabelKeys is comma separated list of keys to use as stream labels
+	// LabelKeys is comma separated list of keys to use as stream labels.
 	LabelKeys []string
-	// LineFormat is the format to use when flattening the record to a log line
+	// LineFormat is the format to use when flattening the record to a log line.
 	LineFormat Format
 	// DropSingleKey if set to true and after extracting label_keys a record only
 	// has a single key remaining, the log line sent to Loki will just be
-	// the value of the record key
+	// the value of the record key.
 	DropSingleKey bool
-	// LabelMap is path to a json file defining how to transform nested records
+	// LabelMap is path to a json file defining how to transform nested records.
 	LabelMap map[string]interface{}
-	// DynamicHostPath is jsonpath in the log labels to the dynamic host
+	// DynamicHostPath is jsonpath in the log labels to the dynamic host.
 	DynamicHostPath map[string]interface{}
-	// DynamicHostRegex is regex to check if the dynamic host is valid
+	// DynamicHostRegex is regex to check if the dynamic host is valid.
 	DynamicHostRegex string
-	// KubernetesMetadata holds the configurations for retrieving the meta data from a tag
+	// KubernetesMetadata holds the configurations for retrieving the meta data from a tag.
 	KubernetesMetadata KubernetesMetadataExtraction
-	//DynamicTenant holds the configurations for retrieving the tenant from a record key
+	//DynamicTenant holds the configurations for retrieving the tenant from a record key.
 	DynamicTenant DynamicTenant
-	//LabelSetInitCapacity the initial capacity of the labelset stream
+	//LabelSetInitCapacity the initial capacity of the labelset stream.
 	LabelSetInitCapacity int
-	//HostnameKey is the key name of the hostname key/value pair
+	//HostnameKey is the key name of the hostname key/value pair.
 	HostnameKey *string
-	//HostnameValue is the value name of the hostname key/value pair
+	//HostnameValue is the value name of the hostname key/value pair.
 	HostnameValue *string
+	//PreservedLabels is the set of label which will be preserved after packing the handled logs.
+	PreservedLabels model.LabelSet
 }
 
 // BufferConfig contains the buffer settings
@@ -577,6 +579,14 @@ func initPluginConfig(cfg Getter, res *Config) error {
 			res.PluginConfig.HostnameValue = &hostnameKeyValueTokens[1]
 		default:
 			return fmt.Errorf("failed to parse HostnameKeyValue. Should consist of <hostname-key>\" \"<optional hostname-value>\". Found %d elements", len(hostnameKeyValueTokens))
+		}
+	}
+
+	res.PluginConfig.PreservedLabels = model.LabelSet{}
+	preservedLabelsStr := cfg.Get("PreservedLabels")
+	if preservedLabelsStr != "" {
+		for _, label := range strings.Split(preservedLabelsStr, ",") {
+			res.PluginConfig.PreservedLabels[model.LabelName(strings.TrimSpace(label))] = ""
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -78,6 +78,7 @@ var (
 		DropSingleKey:        defaultDropSingleKey,
 		DynamicHostRegex:     defaultDynamicHostRegex,
 		LabelSetInitCapacity: defaultLabelSetInitCapacity,
+		PreservedLabels:      model.LabelSet{},
 	}
 
 	defaultBackoffConfig = util.BackoffConfig{
@@ -200,6 +201,7 @@ var _ = Describe("Config", func() {
 				"LabelKeys":       "foo,bar",
 				"DropSingleKey":   "false",
 				"SortByTimestamp": "true",
+				"PreservedLabels": "namesapce, origin",
 			},
 			&Config{
 				PluginConfig: PluginConfig{
@@ -210,6 +212,10 @@ var _ = Describe("Config", func() {
 					DynamicHostRegex:     defaultDynamicHostRegex,
 					KubernetesMetadata:   defaultKubernetesMetadata,
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels: model.LabelSet{
+						"namesapce": "",
+						"origin":    "",
+					},
 				},
 
 				ClientConfig: ClientConfig{
@@ -270,6 +276,7 @@ var _ = Describe("Config", func() {
 					DynamicHostRegex:     defaultDynamicHostRegex,
 					KubernetesMetadata:   defaultKubernetesMetadata,
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig: ClientConfig{
 					GrafanaLokiConfig: client.Config{
@@ -319,6 +326,7 @@ var _ = Describe("Config", func() {
 					DynamicHostRegex:     "shoot--",
 					KubernetesMetadata:   defaultKubernetesMetadata,
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig: ClientConfig{
 					GrafanaLokiConfig: client.Config{
@@ -372,6 +380,7 @@ var _ = Describe("Config", func() {
 					KubernetesMetadata:   defaultKubernetesMetadata,
 					DynamicHostRegex:     defaultDynamicHostRegex,
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig: ClientConfig{
 					GrafanaLokiConfig: client.Config{
@@ -425,6 +434,7 @@ var _ = Describe("Config", func() {
 					DynamicHostRegex:     defaultDynamicHostRegex,
 					KubernetesMetadata:   defaultKubernetesMetadata,
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig: ClientConfig{
 					GrafanaLokiConfig: client.Config{
@@ -480,6 +490,7 @@ var _ = Describe("Config", func() {
 						TagExpression:                      "testExpression",
 					},
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig: ClientConfig{
 					GrafanaLokiConfig: client.Config{
@@ -522,6 +533,7 @@ var _ = Describe("Config", func() {
 					DynamicHostRegex:     defaultDynamicHostRegex,
 					KubernetesMetadata:   defaultKubernetesMetadata,
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 
 				ClientConfig: ClientConfig{
@@ -559,6 +571,7 @@ var _ = Describe("Config", func() {
 						RemoveTenantIdWhenSendingToDefaultURL: true,
 					},
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig:     defaultClientConfig,
 				ControllerConfig: defaultControllerConfig,
@@ -583,6 +596,7 @@ var _ = Describe("Config", func() {
 						RemoveTenantIdWhenSendingToDefaultURL: true,
 					},
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig:     defaultClientConfig,
 				ControllerConfig: defaultControllerConfig,
@@ -607,6 +621,7 @@ var _ = Describe("Config", func() {
 						RemoveTenantIdWhenSendingToDefaultURL: true,
 					},
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig:     defaultClientConfig,
 				ControllerConfig: defaultControllerConfig,
@@ -626,6 +641,7 @@ var _ = Describe("Config", func() {
 					DynamicHostRegex:     defaultDynamicHostRegex,
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
 					HostnameKey:          pointer.StringPtr("hostname"),
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig:     defaultClientConfig,
 				ControllerConfig: defaultControllerConfig,
@@ -646,6 +662,7 @@ var _ = Describe("Config", func() {
 					LabelSetInitCapacity: defaultLabelSetInitCapacity,
 					HostnameKey:          pointer.StringPtr("hostname"),
 					HostnameValue:        pointer.StringPtr("${HOST}"),
+					PreservedLabels:      model.LabelSet{},
 				},
 				ClientConfig:     defaultClientConfig,
 				ControllerConfig: defaultControllerConfig,

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -49,10 +49,11 @@ func (ctl *controller) GetClient(name string) (types.LokiClient, bool) {
 }
 
 func (ctl *controller) newControllerClient(clientConf *config.Config) (ControllerClient, error) {
-	mainClient, err := client.NewClient(clientConf, ctl.logger)
+	mainClient, err := client.NewClient(*clientConf, ctl.logger, client.Options{MultiTenantClient: true})
 	if err != nil {
 		return nil, err
 	}
+
 	c := &controllerClient{
 		mainClient:        mainClient,
 		defaultClient:     ctl.defaultClient,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -96,9 +96,12 @@ func (ctl *controller) Stop() {
 		ctl.lock.Lock()
 		defer ctl.lock.Unlock()
 		for _, client := range ctl.clients {
-			client.Stop()
+			client.StopWait()
 		}
 		ctl.clients = nil
+		if ctl.defaultClient != nil {
+			ctl.defaultClient.StopWait()
+		}
 		if ctl.done != nil {
 			ctl.done <- true
 			ctl.wg.Wait()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
With this PR the logs which are split between the shoot and the central Loki are packed as one stream before being sent to the central Loki. Thi sis needed to stabilize the central part of the logging stack by packing all shoot logs in one stream instead of many.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
All split logs between shoot and central Loki are packed before being sent to the central Loki.
```
