### PR TITLE
Add unit test for sorted client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -49,7 +49,7 @@ func NewClient(cfg config.Config, logger log.Logger, options Options) (types.Lok
 	// When label processing is done the sorting client could be used.
 	if cfg.ClientConfig.SortByTimestamp {
 		ncf = func(c config.Config, l log.Logger) (types.LokiClient, error) {
-			return newSortedClientDecorator(c, nil, l)
+			return NewSortedClientDecorator(c, nil, l)
 		}
 	}
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/gardener/logging/pkg/batch"
 	"github.com/gardener/logging/pkg/config"
 
 	"github.com/cortexproject/cortex/pkg/util"
@@ -91,33 +90,6 @@ var _ = Describe("Client", func() {
 			c, err := NewClient(conf, logger, Options{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
-		})
-	})
-
-	Describe("sortedClient", func() {
-		Describe("#isBatchWaitExceeded", func() {
-			It("should return true when batch is older than 1 second", func() {
-				c := &sortedClient{
-					batchWait: time.Duration(1),
-					batch:     batch.NewBatch(0),
-				}
-				time.Sleep(2 * time.Second)
-				Expect(c.isBatchWaitExceeded()).To(BeTrue())
-			})
-			It("should return false when batch is younger than 10 second", func() {
-				c := &sortedClient{
-					batchWait: time.Duration(10 * time.Second),
-					batch:     batch.NewBatch(0),
-				}
-				Expect(c.isBatchWaitExceeded()).To(BeFalse())
-			})
-			It("should return false when batch is nil", func() {
-				c := &sortedClient{
-					batchWait: 1,
-					batch:     nil,
-				}
-				Expect(c.isBatchWaitExceeded()).To(BeFalse())
-			})
 		})
 	})
 })

--- a/pkg/client/fake_client.go
+++ b/pkg/client/fake_client.go
@@ -32,6 +32,7 @@ func (c *FakeLokiClient) Handle(labels model.LabelSet, timestamp time.Time, line
 	if c.IsStopped || c.IsGracefullyStopped {
 		return fmt.Errorf("client has been stopped")
 	}
+
 	c.Entries = append(c.Entries, Entry{
 		Labels: labels.Clone(),
 		Entry:  logproto.Entry{Timestamp: timestamp, Line: line},

--- a/pkg/client/sorted_client.go
+++ b/pkg/client/sorted_client.go
@@ -43,10 +43,10 @@ type sortedClient struct {
 	wg               sync.WaitGroup
 }
 
-func newSortedClientDecorator(cfg config.Config, newClient NewLokiClientFunc, logger log.Logger) (types.LokiClient, error) {
+func NewSortedClientDecorator(cfg config.Config, newClient NewLokiClientFunc, logger log.Logger) (types.LokiClient, error) {
 	var err error
 	batchWait := cfg.ClientConfig.GrafanaLokiConfig.BatchWait
-	cfg.ClientConfig.GrafanaLokiConfig.BatchWait = 5 * time.Second
+	cfg.ClientConfig.GrafanaLokiConfig.BatchWait = batchWait + (5 * time.Second)
 
 	client, err := newLokiClient(cfg, newClient, logger)
 	if err != nil {

--- a/pkg/client/sorted_client_test.go
+++ b/pkg/client/sorted_client_test.go
@@ -1,0 +1,367 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"os"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/gardener/logging/pkg/client"
+	"github.com/gardener/logging/pkg/config"
+	"github.com/gardener/logging/pkg/types"
+	"github.com/weaveworks/common/logging"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/logproto"
+	promtailclient "github.com/grafana/loki/pkg/promtail/client"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
+)
+
+var _ = Describe("Sorted Client", func() {
+	const (
+		fiveBytesLine   = "Hello"
+		tenByteLine     = "Hello, sir"
+		fifteenByteLine = "Hello, sir Foo!"
+	)
+
+	var (
+		fakeClient           *client.FakeLokiClient
+		sortedClient         types.LokiClient
+		timestampNow         = time.Now()
+		timestampNowPlus1Sec = timestampNow.Add(time.Second)
+		timestampNowPlus2Sec = timestampNowPlus1Sec.Add(time.Second)
+		streamFoo            = model.LabelSet{
+			"namespace_name": "foo",
+		}
+		streamBar = model.LabelSet{
+			"namespace_name": "bar",
+		}
+		streamBuzz = model.LabelSet{
+			"namespace_name": "buzz",
+		}
+	)
+
+	BeforeEach(func() {
+		var err error
+		fakeClient = &client.FakeLokiClient{}
+		var infoLogLevel logging.Level
+		_ = infoLogLevel.Set("info")
+		var clientURL flagext.URLValue
+		err = clientURL.Set("http://localhost:3100/loki/api/v1/push")
+		Expect(err).ToNot(HaveOccurred())
+
+		sortedClient, err = client.NewSortedClientDecorator(config.Config{
+			ClientConfig: config.ClientConfig{
+				GrafanaLokiConfig: promtailclient.Config{
+					BatchWait: 3 * time.Second,
+					BatchSize: 90,
+					URL:       clientURL,
+				},
+				NumberOfBatchIDs: 2,
+			},
+		},
+			func(_ config.Config, _ log.Logger) (types.LokiClient, error) {
+				return fakeClient, nil
+			},
+			level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), infoLogLevel.Gokit))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sortedClient).NotTo(BeNil())
+	})
+
+	Describe("#Handle", func() {
+		Context("Sorting", func() {
+			It("should sort correctly one stream", func() {
+				// Because BatchWait is 10 seconds we shall wait at least such
+				// to be sure that the entries are flushed to the fake client.
+				entries := []client.Entry{
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus1Sec,
+							Line:      tenByteLine,
+						},
+					},
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus2Sec,
+							Line:      fifteenByteLine,
+						},
+					},
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNow,
+							Line:      fiveBytesLine,
+						},
+					},
+				}
+
+				for _, entry := range entries {
+					err := sortedClient.Handle(entry.Labels, entry.Timestamp, entry.Line)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				time.Sleep(4 * time.Second)
+				Expect(len(fakeClient.Entries)).To(Equal(3))
+				Expect(fakeClient.Entries[0]).To(Equal(client.Entry{
+					Labels: MergeLabelSets(streamFoo, model.LabelSet{"id": "0"}),
+					Entry: logproto.Entry{
+						Timestamp: timestampNow,
+						Line:      fiveBytesLine,
+					}}))
+				Expect(fakeClient.Entries[1]).To(Equal(client.Entry{
+					Labels: MergeLabelSets(streamFoo, model.LabelSet{"id": "0"}),
+					Entry: logproto.Entry{
+						Timestamp: timestampNowPlus1Sec,
+						Line:      tenByteLine,
+					}}))
+				Expect(fakeClient.Entries[2]).To(Equal(client.Entry{
+					Labels: MergeLabelSets(streamFoo, model.LabelSet{"id": "0"}),
+					Entry: logproto.Entry{
+						Timestamp: timestampNowPlus2Sec,
+						Line:      fifteenByteLine,
+					}}))
+			})
+
+			It("should sort correctly three stream", func() {
+				// Because BatchWait is 3 seconds we shall wait at least such
+				// to be sure that the entries are flushed to the fake client.
+				entries := []client.Entry{
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus1Sec,
+							Line:      tenByteLine,
+						},
+					},
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus2Sec,
+							Line:      fifteenByteLine,
+						},
+					},
+					{
+						Labels: streamBuzz,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus1Sec,
+							Line:      tenByteLine,
+						},
+					},
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNow,
+							Line:      fiveBytesLine,
+						},
+					},
+					{
+						Labels: streamBar,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus1Sec,
+							Line:      tenByteLine,
+						},
+					},
+					{
+						Labels: streamBuzz,
+						Entry: logproto.Entry{
+							Timestamp: timestampNow,
+							Line:      fiveBytesLine,
+						},
+					},
+					{
+						Labels: streamBar,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus2Sec,
+							Line:      fifteenByteLine,
+						},
+					},
+					{
+						Labels: streamBar,
+						Entry: logproto.Entry{
+							Timestamp: timestampNow,
+							Line:      fiveBytesLine,
+						},
+					},
+					{
+						Labels: streamBuzz,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus2Sec,
+							Line:      fifteenByteLine,
+						},
+					},
+				}
+
+				for _, entry := range entries {
+					err := sortedClient.Handle(entry.Labels, entry.Timestamp, entry.Line)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				time.Sleep(4 * time.Second)
+				Expect(len(fakeClient.Entries)).To(Equal(9))
+				for _, stream := range []model.LabelSet{
+					streamFoo,
+					streamBar,
+					streamBuzz,
+				} {
+					oldestTime := timestampNow.Add(-1 * time.Second)
+					streamNamespace := stream["namespace_name"]
+
+					for _, entry := range fakeClient.Entries {
+						entryNamespace := entry.Labels["namespace_name"]
+						if string(entryNamespace) == string(streamNamespace) {
+							Expect(entry.Timestamp.After(oldestTime)).To(BeTrue())
+							oldestTime = entry.Timestamp
+						}
+					}
+				}
+			})
+		})
+
+		Context("BatchSize", func() {
+			It("It should not flush if batch size is less or equal to BatchSize", func() {
+				entry := client.Entry{
+					Labels: streamFoo,
+					Entry: logproto.Entry{
+						Timestamp: timestampNowPlus1Sec,
+						Line:      fifteenByteLine + fifteenByteLine + fifteenByteLine + fifteenByteLine + fifteenByteLine + tenByteLine,
+					},
+				}
+
+				err := sortedClient.Handle(entry.Labels, entry.Timestamp, entry.Line)
+				Expect(err).ToNot(HaveOccurred())
+
+				time.Sleep(time.Second)
+				Expect(len(fakeClient.Entries)).To(Equal(0))
+			})
+
+			It("It should flush if batch size is greater than BatchSize", func() {
+				entries := []client.Entry{
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus1Sec,
+							Line:      fifteenByteLine + fifteenByteLine + fifteenByteLine + fifteenByteLine + fifteenByteLine + tenByteLine,
+						},
+					},
+					{
+						Labels: streamFoo,
+						Entry: logproto.Entry{
+							Timestamp: timestampNowPlus1Sec,
+							Line:      fifteenByteLine + fifteenByteLine,
+						},
+					},
+				}
+
+				for _, entry := range entries {
+					err := sortedClient.Handle(entry.Labels, entry.Timestamp, entry.Line)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				time.Sleep(time.Second)
+				// Only the first entry will be flushed.
+				// The second one stays in the next batch.
+				Expect(len(fakeClient.Entries)).To(Equal(1))
+			})
+		})
+
+		Context("BatchSize", func() {
+			It("It should not flush until BatchWait time duration is passed", func() {
+				entry := client.Entry{
+					Labels: streamFoo,
+					Entry: logproto.Entry{
+						Timestamp: timestampNowPlus1Sec,
+						Line:      fifteenByteLine,
+					},
+				}
+
+				err := sortedClient.Handle(entry.Labels, entry.Timestamp, entry.Line)
+				Expect(err).ToNot(HaveOccurred())
+
+				time.Sleep(time.Second)
+				Expect(len(fakeClient.Entries)).To(Equal(0))
+			})
+
+			It("It should flush after BatchWait time duration is passed", func() {
+				entry := client.Entry{
+					Labels: streamFoo,
+					Entry: logproto.Entry{
+						Timestamp: timestampNowPlus1Sec,
+						Line:      fifteenByteLine,
+					},
+				}
+
+				err := sortedClient.Handle(entry.Labels, entry.Timestamp, entry.Line)
+				Expect(err).ToNot(HaveOccurred())
+
+				time.Sleep(4 * time.Second)
+				Expect(len(fakeClient.Entries)).To(Equal(1))
+
+				entry.Labels = MergeLabelSets(entry.Labels, model.LabelSet{"id": "0"})
+				Expect(fakeClient.Entries[0]).To(Equal(entry))
+			})
+		})
+	})
+
+	Describe("#Stop", func() {
+		It("should stop", func() {
+			Expect(fakeClient.IsGracefullyStopped).To(BeFalse())
+			Expect(fakeClient.IsStopped).To(BeFalse())
+			sortedClient.Stop()
+			Expect(fakeClient.IsGracefullyStopped).To(BeFalse())
+			Expect(fakeClient.IsStopped).To(BeTrue())
+		})
+	})
+
+	Describe("#StopWait", func() {
+		It("should stop", func() {
+			Expect(fakeClient.IsGracefullyStopped).To(BeFalse())
+			Expect(fakeClient.IsStopped).To(BeFalse())
+			sortedClient.StopWait()
+			Expect(fakeClient.IsGracefullyStopped).To(BeTrue())
+			Expect(fakeClient.IsStopped).To(BeFalse())
+		})
+	})
+})
+
+// MergeLabelSets merges the content of the newLabelSet with the oldLabelSet. If a key already exists then
+// it gets overwritten by the last value with the same key.
+func MergeLabelSets(oldLabelSet model.LabelSet, newLabelSet ...model.LabelSet) model.LabelSet {
+	var out model.LabelSet
+
+	if oldLabelSet != nil {
+		out = make(model.LabelSet)
+	}
+	for k, v := range oldLabelSet {
+		out[k] = v
+	}
+
+	for _, newMap := range newLabelSet {
+		if newMap != nil && out == nil {
+			out = make(model.LabelSet)
+		}
+
+		for k, v := range newMap {
+			out[k] = v
+		}
+	}
+
+	return out
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind test
/area logging

**What this PR does / why we need it**:
This PR add unit tests for the sorted Loki client.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
