### PR TITLE
Make able event-logger to watch events in multiple namespace specified by flag

### DIFF
--- a/pkg/events/gardener_event_watcher.go
+++ b/pkg/events/gardener_event_watcher.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	kubeinformers "k8s.io/client-go/informers"
+)
+
+type GardenerEventWatcherConfig struct {
+	SeedEventWatcherConfig     EventWatcherConfig
+	SeedKubeInformerFactories  []kubeinformers.SharedInformerFactory
+	ShootEventWatcherConfig    EventWatcherConfig
+	ShootKubeInformerFactories []kubeinformers.SharedInformerFactory
+}
+
+type GardenerEventWatcher struct {
+	SeedKubeInformerFactories  []kubeinformers.SharedInformerFactory
+	ShootKubeInformerFactories []kubeinformers.SharedInformerFactory
+}
+
+func (e *GardenerEventWatcherConfig) New() *GardenerEventWatcher {
+	for indx, namespace := range e.SeedEventWatcherConfig.Namespaces {
+		fmt.Println("**********MAKE SEED EVENT WATCHER FOR NAMESPACE: ", namespace, "*****************")
+		_ = e.SeedKubeInformerFactories[indx].InformerFor(&v1.Event{},
+			NewEventInformerFuncForNamespace(
+				"seed",
+				namespace,
+			),
+		)
+	}
+
+	for indx, namespace := range e.ShootEventWatcherConfig.Namespaces {
+		fmt.Println("**********MAKE SHOOT EVENT WATCHER FOR NAMESPACE: ", namespace, "*****************")
+		_ = e.ShootKubeInformerFactories[indx].InformerFor(&v1.Event{},
+			NewEventInformerFuncForNamespace(
+				"shoot",
+				namespace,
+			),
+		)
+	}
+
+	return &GardenerEventWatcher{
+		SeedKubeInformerFactories:  e.SeedKubeInformerFactories,
+		ShootKubeInformerFactories: e.ShootKubeInformerFactories,
+	}
+}
+
+func (e *GardenerEventWatcher) Run(stopCh <-chan struct{}) {
+	for _, informerFactory := range e.SeedKubeInformerFactories {
+		informerFactory.Start(stopCh)
+	}
+
+	for _, informerFactory := range e.ShootKubeInformerFactories {
+		informerFactory.Start(stopCh)
+	}
+	<-stopCh
+}

--- a/pkg/events/options.go
+++ b/pkg/events/options.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"github.com/spf13/pflag"
+)
+
+func (o *Options) Validate() []error {
+	//TODO: vlvasilev implement me
+	errors := []error{}
+	errors = append(errors, nil)
+	return errors
+}
+
+func (o *Options) ApplyTo(config *EventWatcherConfig) error {
+	config.Kubeconfig = o.Kubeconfig
+	config.Namespaces = o.Namespaces
+	return nil
+}
+
+// AddFlags adds all flags to the given FlagSet.
+func (o *SeedOptions) AddFlags(fs *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
+	fs.StringVar(&o.Kubeconfig, "seed-kubeconfig", "", "The kubeconfig for the seed cluster")
+	fs.StringSliceVar(&o.Namespaces, "seed-event-namespaces", []string{"kube-system"}, "The namespaces of the seed events")
+}
+
+// Validate all flags of the given Options.
+func (o *SeedOptions) Validate() []error {
+	return o.Options.Validate()
+}
+
+func (o *SeedOptions) ApplyTo(config *EventWatcherConfig) error {
+	return o.Options.ApplyTo(config)
+}
+
+// AddFlags adds all flags to the given FlagSet.
+func (o *ShootOptions) AddFlags(fs *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
+	fs.StringVar(&o.Kubeconfig, "shoot-kubeconfig", "", "The kubeconfig for the shoot cluster")
+	fs.StringSliceVar(&o.Namespaces, "shoot-event-namespaces", []string{"kube-system", "default"}, "The namespaces of the shoot events")
+}
+
+// Validate all flags of the given Options.
+func (o *ShootOptions) Validate() []error {
+	return o.Options.Validate()
+}
+
+func (o *ShootOptions) ApplyTo(config *EventWatcherConfig) error {
+	return o.Options.ApplyTo(config)
+}

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -16,30 +16,17 @@ package events
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeinformers "k8s.io/client-go/informers"
 )
 
 type EventWatcherConfig struct {
 	Kubeconfig string //Do I need this field?
-	Namespace  string
-}
-
-type GardenerEventWatcherConfig struct {
-	SeedEventWatcherConfig   EventWatcherConfig
-	SeedKubeInformerFactory  kubeinformers.SharedInformerFactory
-	ShootEventWatcherConfig  EventWatcherConfig
-	ShootKubeInformerFactory kubeinformers.SharedInformerFactory
-}
-
-type GardenerEventWatcher struct {
-	SeedKubeInformerFactory  kubeinformers.SharedInformerFactory
-	ShootKubeInformerFactory kubeinformers.SharedInformerFactory
+	Namespaces []string
 }
 
 // Options has all the context and parameters needed to run a Gardener Event Logger.
 type Options struct {
 	Kubeconfig string
-	Namespace  string
+	Namespaces []string
 }
 
 type SeedOptions struct {
@@ -51,8 +38,9 @@ type ShootOptions struct {
 }
 
 type event struct {
-	Origin         string      `json:"origin" protobuf:"bytes,9,name=origin"`
-	Type           string      `json:"type,omitempty" protobuf:"bytes,9,opt,name=type"`
+	Origin         string      `json:"origin" protobuf:"bytes,6,name=origin"`
+	Namespace      string      `json:"namespace" protobuf:"bytes,9,name=namespace"`
+	Type           string      `json:"type,omitempty" protobuf:"bytes,4,opt,name=type"`
 	Count          int32       `json:"count,omitempty" protobuf:"varint,8,opt,name=count"`
 	FirstTimestamp metav1.Time `json:"firstTimestamp,omitempty" protobuf:"bytes,6,opt,name=firstTimestamp"`
 	LastTimestamp  metav1.Time `json:"lastTimestamp,omitempty" protobuf:"bytes,7,opt,name=lastTimestamp"`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
With this PR the event-logger is capable of watching events in all namespaces specified by the flags `--seed-event-namespaces` and `--shoot-event-namespaces`. The namespaces are set as coma separeted values `kube-system,default`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The event-logger watches events of multiple namespaces specified by `--seed-event-namespaces` and `--shoot-event-namespaces` like coma-separated values.
The flags `--seed-event-namespace` and `--shoot-event-namespace` are dropped.
```
