### PR TITLE
Always clone the label set in multitenant client befor sending the logs to the next client

### DIFF
--- a/pkg/client/multi_tenant_client.go
+++ b/pkg/client/multi_tenant_client.go
@@ -30,8 +30,7 @@ import (
 )
 
 type multiTenantClient struct {
-	lokiclient   types.LokiClient
-	copyLabelSet bool
+	lokiclient types.LokiClient
 }
 
 const (
@@ -48,8 +47,7 @@ func NewMultiTenantClientDecorator(cfg config.Config, newClient NewLokiClientFun
 	}
 
 	return &multiTenantClient{
-		lokiclient:   client,
-		copyLabelSet: true,
+		lokiclient: client,
 	}, nil
 }
 
@@ -67,11 +65,7 @@ func (c *multiTenantClient) Handle(ls model.LabelSet, t time.Time, s string) err
 
 	var errs []error
 	for _, tenant := range tenants {
-		tmpLs := ls
-		if c.copyLabelSet {
-			tmpLs = ls.Clone()
-		}
-
+		tmpLs := ls.Clone()
 		tmpLs[client.ReservedLabelTenantID] = model.LabelValue(tenant)
 
 		err := c.lokiclient.Handle(tmpLs, t, s)
@@ -131,16 +125,13 @@ func (c *multiTenantClient) handleStream(stream batch.Stream) error {
 
 	var combineErr error
 	for _, tenant := range tenants {
-		ls := stream.Labels
-		if c.copyLabelSet {
-			ls = stream.Labels.Clone()
-		}
+		ls := stream.Labels.Clone()
 		ls[client.ReservedLabelTenantID] = model.LabelValue(tenant)
+
 		err := c.handleEntries(ls, stream.Entries)
 		if err != nil {
 			combineErr = giterrors.Wrap(combineErr, err.Error())
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/area logging

**What this PR does / why we need it**:
With this PR the option to not clone the labels set in the `multitenant` client is removed. Now the label set is always copied.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Remove race condition in the multitenant client when labels set is not cloned.
```
