### PR TITLE
Set the name of the batch ID label from the pluging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ It also adds additional configurations that aim to improve plugin's performance 
 | DropLogEntryWithoutK8sMetadata | When metadata is missing for the log entry, it will be dropped | `false`
 | ControllerSyncTimeout | Time to wait for cluster object synchronization | 60 seconds
 | NumberOfBatchIDs | The number of id per batch. This increase the number of loki label streams | 10
+| IdLabelName | The name of the batch ID label kye in the stream label set | `id`
 | DeletedClientTimeExpiration | The time duration after a client for deleted cluster will be considered for expired | 1 hour
 | DynamicTenant | When set the value is split on space delimiter to 3 tokens. The first token is the tenant to use, the second one is the field to search for matching. The third is the regex to match token 2. | none
 | RemoveTenantIdWhenSendingToDefaultURL | When `DynamicTenant` is set this flag decide whether to remove the record with dynamic tenant or not when sending them to the default `URL` | true

--- a/cmd/fluent-bit-loki-plugin/out_loki.go
+++ b/cmd/fluent-bit-loki-plugin/out_loki.go
@@ -145,6 +145,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	level.Info(paramLogger).Log("TagExpression", fmt.Sprintf("%+v", conf.PluginConfig.KubernetesMetadata.TagExpression))
 	level.Info(paramLogger).Log("DropLogEntryWithoutK8sMetadata", fmt.Sprintf("%+v", conf.PluginConfig.KubernetesMetadata.DropLogEntryWithoutK8sMetadata))
 	level.Info(paramLogger).Log("NumberOfBatchIDs", fmt.Sprintf("%+v", conf.ClientConfig.NumberOfBatchIDs))
+	level.Info(paramLogger).Log("IdLabelName", fmt.Sprintf("%+v", conf.ClientConfig.IdLabelName))
 	level.Info(paramLogger).Log("DeletedClientTimeExpiration", fmt.Sprintf("%+v", conf.ControllerConfig.DeletedClientTimeExpiration))
 	level.Info(paramLogger).Log("DynamicTenant", fmt.Sprintf("%+v", conf.PluginConfig.DynamicTenant.Tenant))
 	level.Info(paramLogger).Log("DynamicField", fmt.Sprintf("%+v", conf.PluginConfig.DynamicTenant.Field))

--- a/pkg/batch/batch_test.go
+++ b/pkg/batch/batch_test.go
@@ -27,10 +27,10 @@ var _ = Describe("Batch", func() {
 	Describe("#NewBatch", func() {
 		It("Should create new batch", func() {
 			var id uint64 = 11
-			batch := NewBatch(id % 10)
+			batch := NewBatch(model.LabelName("id"), id%10)
 			Expect(batch).ToNot(BeNil())
-			Expect(batch.Streams).ToNot(BeNil())
-			Expect(batch.Bytes).To(Equal(0))
+			Expect(batch.streams).ToNot(BeNil())
+			Expect(batch.bytes).To(Equal(0))
 			Expect(batch.id).To(Equal(uint64(1)))
 
 		})
@@ -69,15 +69,15 @@ var _ = Describe("Batch", func() {
 
 	ginkgoTable.DescribeTable("#Add",
 		func(args addTestArgs) {
-			batch := NewBatch(0)
+			batch := NewBatch(model.LabelName("id"), 0)
 			for _, entry := range args.entries {
 				batch.Add(entry.LabelSet, entry.Timestamp, entry.Line)
 			}
 
-			Expect(len(batch.Streams)).To(Equal(len(args.expectedBatch.Streams)))
-			Expect(batch.Bytes).To(Equal(args.expectedBatch.Bytes))
-			for streamName, stream := range batch.Streams {
-				s, ok := args.expectedBatch.Streams[streamName]
+			Expect(len(batch.streams)).To(Equal(len(args.expectedBatch.streams)))
+			Expect(batch.bytes).To(Equal(args.expectedBatch.bytes))
+			for streamName, stream := range batch.streams {
+				s, ok := args.expectedBatch.streams[streamName]
 				Expect(ok).To(BeTrue())
 				Expect(stream).To(Equal(s))
 			}
@@ -91,7 +91,7 @@ var _ = Describe("Batch", func() {
 				},
 			},
 			expectedBatch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -103,7 +103,7 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp1,
 					},
 				},
-				Bytes: 5,
+				bytes: 5,
 			},
 		}),
 		ginkgoTable.Entry("add two entry for one stream", addTestArgs{
@@ -120,7 +120,7 @@ var _ = Describe("Batch", func() {
 				},
 			},
 			expectedBatch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -136,7 +136,7 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp2,
 					},
 				},
-				Bytes: 10,
+				bytes: 10,
 			},
 		}),
 		ginkgoTable.Entry("Add two entry for two stream", addTestArgs{
@@ -153,7 +153,7 @@ var _ = Describe("Batch", func() {
 				},
 			},
 			expectedBatch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -175,7 +175,7 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp2,
 					},
 				},
-				Bytes: 10,
+				bytes: 10,
 			},
 		}),
 		ginkgoTable.Entry("Add two entry per each for two streams", addTestArgs{
@@ -202,7 +202,7 @@ var _ = Describe("Batch", func() {
 				},
 			},
 			expectedBatch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -232,7 +232,7 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp2,
 					},
 				},
-				Bytes: 20,
+				bytes: 20,
 			},
 		}),
 	)
@@ -243,7 +243,7 @@ var _ = Describe("Batch", func() {
 		},
 		ginkgoTable.Entry("Sort batch with single stream with single entry", sortTestArgs{
 			batch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -255,10 +255,10 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp1,
 					},
 				},
-				Bytes: 5,
+				bytes: 5,
 			},
 			expectedBatch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -270,12 +270,12 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp1,
 					},
 				},
-				Bytes: 5,
+				bytes: 5,
 			},
 		}),
 		ginkgoTable.Entry("Sort batch with single stream with two entry", sortTestArgs{
 			batch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -292,10 +292,10 @@ var _ = Describe("Batch", func() {
 						lastTimestamp:     timeStamp2,
 					},
 				},
-				Bytes: 5,
+				bytes: 5,
 			},
 			expectedBatch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -311,12 +311,12 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp2,
 					},
 				},
-				Bytes: 5,
+				bytes: 5,
 			},
 		}),
 		ginkgoTable.Entry("Sort batch with two stream with two entry", sortTestArgs{
 			batch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -348,10 +348,10 @@ var _ = Describe("Batch", func() {
 						lastTimestamp:     timeStamp2,
 					},
 				},
-				Bytes: 5,
+				bytes: 5,
 			},
 			expectedBatch: Batch{
-				Streams: map[string]*Stream{
+				streams: map[string]*Stream{
 					label1.String(): &Stream{
 						Labels: label1ID0.Clone(),
 						Entries: []Entry{
@@ -381,15 +381,8 @@ var _ = Describe("Batch", func() {
 						lastTimestamp: timeStamp2,
 					},
 				},
-				Bytes: 5,
+				bytes: 5,
 			},
 		}),
 	)
 })
-
-// type Stream struct {
-// 	Labels            model.LabelSet
-// 	Entries           []Entry
-// 	isEntryOutOfOrder bool
-// 	lastTimestamp     time.Time
-// }

--- a/pkg/client/sorted_client_test.go
+++ b/pkg/client/sorted_client_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Sorted Client", func() {
 					URL:       clientURL,
 				},
 				NumberOfBatchIDs: 2,
+				IdLabelName:      model.LabelName("id"),
 			},
 		},
 			func(_ config.Config, _ log.Logger) (types.LokiClient, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,7 +55,7 @@ const (
 	DefaultKubernetesMetadataTagPrefix = "kubernetes\\.var\\.log\\.containers"
 )
 
-//Config holds all of the needet properties of the loki output plugin
+// Config holds all of the needet properties of the loki output plugin
 type Config struct {
 	ClientConfig     ClientConfig
 	ControllerConfig ControllerConfig
@@ -75,6 +75,8 @@ type ClientConfig struct {
 	// NumberOfBatchIDs is number of id per batch.
 	// This increase the number of loki label streams
 	NumberOfBatchIDs uint64
+	// IdLabelName is the name of the batch id label key.
+	IdLabelName model.LabelName
 }
 
 // ControllerConfig hold the configuration fot the Loki client controller
@@ -399,6 +401,16 @@ func initClientConfig(cfg Getter, res *Config) error {
 	} else {
 		res.ClientConfig.NumberOfBatchIDs = 10
 	}
+
+	idLabelNameStr := cfg.Get("IdLabelName")
+	if idLabelNameStr == "" {
+		idLabelNameStr = "id"
+	}
+	idLabelName := model.LabelName(idLabelNameStr)
+	if !idLabelName.IsValid() {
+		return fmt.Errorf("invalid IdLabelName: %s", idLabelNameStr)
+	}
+	res.ClientConfig.IdLabelName = idLabelName
 
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,6 +115,7 @@ var (
 		GrafanaLokiConfig: defaultGrafanaLokiConfig,
 		BufferConfig:      defaultBufferConfig,
 		NumberOfBatchIDs:  defaultNumberOfBatchIDs,
+		IdLabelName:       model.LabelName("id"),
 	}
 
 	defaultMainControllerClientConfig = ControllerClientConfiguration{
@@ -234,6 +235,7 @@ var _ = Describe("Config", func() {
 						DqueConfig: defaultDqueConfig,
 					},
 					NumberOfBatchIDs: defaultNumberOfBatchIDs,
+					IdLabelName:      model.LabelName("id"),
 					SortByTimestamp:  true,
 				},
 				ControllerConfig: defaultControllerConfig,
@@ -289,6 +291,7 @@ var _ = Describe("Config", func() {
 						Timeout:        defaultTimeout,
 					},
 					BufferConfig:     defaultBufferConfig,
+					IdLabelName:      model.LabelName("id"),
 					NumberOfBatchIDs: defaultNumberOfBatchIDs,
 				},
 				ControllerConfig: defaultControllerConfig,
@@ -339,6 +342,7 @@ var _ = Describe("Config", func() {
 						Timeout:        defaultTimeout,
 					},
 					BufferConfig:     defaultBufferConfig,
+					IdLabelName:      model.LabelName("id"),
 					NumberOfBatchIDs: defaultNumberOfBatchIDs,
 				},
 				ControllerConfig: ControllerConfig{
@@ -403,6 +407,7 @@ var _ = Describe("Config", func() {
 						},
 					},
 					NumberOfBatchIDs: defaultNumberOfBatchIDs,
+					IdLabelName:      model.LabelName("id"),
 				},
 				ControllerConfig: defaultControllerConfig,
 				LogLevel:         warnLogLevel,
@@ -452,6 +457,7 @@ var _ = Describe("Config", func() {
 					},
 					BufferConfig:     defaultBufferConfig,
 					NumberOfBatchIDs: defaultNumberOfBatchIDs,
+					IdLabelName:      model.LabelName("id"),
 				},
 				ControllerConfig: defaultControllerConfig,
 				LogLevel:         warnLogLevel,
@@ -504,6 +510,7 @@ var _ = Describe("Config", func() {
 					},
 					BufferConfig:     defaultBufferConfig,
 					NumberOfBatchIDs: defaultNumberOfBatchIDs,
+					IdLabelName:      model.LabelName("id"),
 				},
 				ControllerConfig: defaultControllerConfig,
 				LogLevel:         warnLogLevel,
@@ -548,6 +555,7 @@ var _ = Describe("Config", func() {
 					},
 					BufferConfig:     defaultBufferConfig,
 					NumberOfBatchIDs: defaultNumberOfBatchIDs,
+					IdLabelName:      model.LabelName("id"),
 				},
 				ControllerConfig: defaultControllerConfig,
 				LogLevel:         warnLogLevel,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
Set the batch id name via `IdLabelName` from the plugin configuration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The name of the batch ID label can be set via `IdLabelName` from the plugin configuration.
```
