### PR TITLE
Prevent send on closed chanel when closing the sorted client

### DIFF
--- a/pkg/client/sorted_client.go
+++ b/pkg/client/sorted_client.go
@@ -81,9 +81,6 @@ func (c *sortedClient) run() {
 	maxWaitCheck := time.NewTicker(maxWaitCheckFrequency)
 
 	defer func() {
-		if c.batch != nil {
-			c.sendBatch()
-		}
 		maxWaitCheck.Stop()
 		c.wg.Done()
 	}()
@@ -167,17 +164,22 @@ func (c *sortedClient) addToBatch(e Entry) {
 func (c *sortedClient) Stop() {
 	c.once.Do(func() {
 		close(c.quit)
+		c.wg.Wait()
 		c.lokiclient.Stop()
 	})
-	c.wg.Wait()
+
 }
 
 func (c *sortedClient) StopWait() {
 	c.once.Do(func() {
 		close(c.quit)
+		c.wg.Wait()
+		if c.batch != nil {
+			c.sendBatch()
+		}
 		c.lokiclient.StopWait()
 	})
-	c.wg.Wait()
+
 }
 
 // Handle implement EntryHandler; adds a new line to the next batch; send is async.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind TODO
/area logging

**What this PR does / why we need it**:
When closing the SortedClient which has an unsent batch it throws panic because the underlying client is closing without waiting for the final batch to be sent. This PR fixes this issue.

**Which issue(s) this PR fixes**:
Fixes [#152](https://github.com/gardener/logging/issues/152)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix sending on a closed channel in the SortedClient when closing it before the last batch is sent.
```
