### PR TITLE
Build static telegraf with iptables utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,57 @@ WORKDIR /
 
 ENTRYPOINT [ "/event-logger" ]
 
-#############      telegraf       #############
-FROM telegraf:1.24.2 AS telegraf
+#############      telegraf-builder       #############
+FROM golang:1.19.2 AS telegraf-builder
 
-RUN apt update && apt install -y iptables sudo && apt clean
+RUN git clone https://github.com/influxdata/telegraf.git
+WORKDIR /go/telegraf
+RUN git checkout v1.24.2
+RUN CGO_ENABLED=0 make build
+
+#############      iptables-builder       #############
+FROM alpine:3.16.2 as iptables-builder
+
+RUN apk add --update bash sudo iptables && \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /volume
+
+RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables ./usr/lib/bash ./tmp ./run ./etc/bash ./etc/openvpn ./usr/lib/openvpn/plugins ./etc/iproute2 ./etc/terminfo ./etc/logrotate.d ./etc/network/if-up.d ./usr/share/udhcpc ./etc/ssl/misc ./usr/lib/engines-1.1 ./run ./usr/lib/sudo \
+    && cp -d /lib/ld-musl-* ./lib                                           && echo "package musl" \
+    && cp -d /lib/libc.musl-* ./lib                                         && echo "package musl" \
+    && cp -d -r /etc/terminfo/* ./etc/terminfo                              && echo "package ncurses-terminfo-base" \
+    && cp -d /usr/lib/libformw.so.* ./usr/lib                               && echo "package ncurses-libs" \
+    && cp -d /usr/lib/libmenuw.so.* ./usr/lib                               && echo "package ncurses-libs" \
+    && cp -d /usr/lib/libncursesw.so.* ./usr/lib                            && echo "package ncurses-libs" \
+    && cp -d /usr/lib/libpanelw.so.* ./usr/lib                              && echo "package ncurses-libs" \
+    && cp -d /usr/lib/libreadline.so.* ./usr/lib                            && echo "package readline" \
+    && cp -d /etc/inputrc ./etc                                             && echo "package readline" \
+    && cp -d /bin/bash ./bin                                                && echo "package bash" \
+    && cp -d /etc/bash/bashrc ./etc/bash                                    && echo "package bash" \
+    && cp -d /usr/lib/bash/* ./usr/lib/bash                                 && echo "package bash" \
+    && cp -d /lib/libz.* ./lib                                              && echo "package zlib" \
+    && cp -d /usr/lib/libmnl.* ./usr/lib                                    && echo "package libmnl" \
+    && cp -d /usr/lib/libnftnl* ./usr/lib                                   && echo "package libnftnl" \
+    && cp -d /etc/ethertypes ./etc                                          && echo "package iptables" \
+    && cp -d /sbin/iptables* ./sbin                                         && echo "package iptables" \
+    && cp -d /sbin/xtables* ./sbin                                          && echo "package iptables" \
+    && cp -d /usr/lib/libip4* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libip6* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libipq* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libxtables* ./usr/lib                                 && echo "package iptables" \
+    && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables" \
+    && cp -d /usr/lib/sudo/* ./usr/lib/sudo                                 && echo "package sudo" \
+    && cp -d /etc/sudoers ./etc                                             && echo "package sudo" \
+    && cp -d /etc/passwd ./etc                                              && echo "package sudo" \
+    && cp -d /usr/bin/sudo ./usr/sbin                                       && echo "package sudo" \
+    && touch ./run/xtables.lock                                             && echo "create /run/xtables.lock"
+
+#############      telegraf       #############
+FROM scratch AS telegraf
+
+COPY --from=iptables-builder /volume /
+
+COPY --from=telegraf-builder /go/telegraf/telegraf /usr/bin/telegraf
+
+CMD [ "/usr/bin/telegraf"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
With this PR the `Telegraf` is built as static binary without `CGO`.
Also, the `iptables`, `bash` and `sudo` are installed.
The image is built from scratch with only the required libs.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Telegraf image used by Loki pod is built from scratch with static binary.
```
