### PR TITLE
labelMapPath configuration now supports also row json data

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -487,9 +488,14 @@ func initPluginConfig(cfg Getter, res *Config) error {
 
 	labelMapPath := cfg.Get("LabelMapPath")
 	if labelMapPath != "" {
-		content, err := ioutil.ReadFile(labelMapPath)
-		if err != nil {
-			return fmt.Errorf("failed to open LabelMap file: %s", err)
+		var content []byte
+		if _, err := os.Stat(labelMapPath); err == nil {
+			content, err = ioutil.ReadFile(labelMapPath)
+			if err != nil {
+				return fmt.Errorf("failed to open LabelMap file: %s", err)
+			}
+		} else if errors.Is(err, os.ErrNotExist) {
+			content = []byte(labelMapPath)
 		}
 		if err := json.Unmarshal(content, &res.PluginConfig.LabelMap); err != nil {
 			return fmt.Errorf("failed to Unmarshal LabelMap file: %s", err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging
/priority normal

**What this PR does / why we need it**:
labelMapPath configuration now supports also row json data

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
