### PR TITLE
Bump GO version from 1.19.3->1.19.4 and telegraf from 1.24.5->1.25.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -34,7 +34,7 @@ logging:
             target: event-logger
     steps:
       verify:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.4'
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.19.3 AS plugin-builder
+FROM golang:1.19.4 AS plugin-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -22,7 +22,7 @@ WORKDIR /
 CMD /bin/cp /source/plugins/. /plugins
 
 #############      image-builder       #############
-FROM golang:1.19.3 AS image-builder
+FROM golang:1.19.4 AS image-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -51,11 +51,11 @@ WORKDIR /
 ENTRYPOINT [ "/event-logger" ]
 
 #############      telegraf-builder       #############
-FROM golang:1.19.3 AS telegraf-builder
+FROM golang:1.19.4 AS telegraf-builder
 
 RUN git clone https://github.com/influxdata/telegraf.git
 WORKDIR /go/telegraf
-RUN git checkout v1.24.2
+RUN git checkout v1.25.0
 RUN CGO_ENABLED=0 make build
 
 #############      iptables-builder       #############


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement 
/area logging
/priority normal

**What this PR does / why we need it**:
Bump golang version from 1.19.3 to 1.19.4 and telegraf version from 1.24.2 to 1.25.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
upgrade golang version from 1.19.3 to 1.19.4.
```
```other operator
upgrade telegraf version from 1.24.2 to 1.25.0.
```