### PR TITLE
Build tune2fs image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -72,7 +72,7 @@ logging:
                 availability_requirement: 'low'
     steps:
       verify:
-        image: 'golang:1.19.5'
+        image: 'golang:1.20.2'
   jobs:
     head-update:
       traits:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ REGISTRY                              := eu.gcr.io/gardener-project/gardener
 FLUENT_BIT_TO_LOKI_IMAGE_REPOSITORY   := $(REGISTRY)/fluent-bit-to-loki
 LOKI_CURATOR_IMAGE_REPOSITORY         := $(REGISTRY)/loki-curator
 TELEGRAF_IMAGE_REPOSITORY             := $(REGISTRY)/telegraf-iptables
+TUNE2FS_IMAGE_REPOSITORY              := $(REGISTRY)/tune2fs
 EVENT_LOGGER_IMAGE_REPOSITORY         := $(REGISTRY)/event-logger
 IMAGE_TAG                             := $(VERSION)
 EFFECTIVE_VERSION                     := $(VERSION)-$(shell git rev-parse HEAD)
@@ -61,6 +62,7 @@ docker-images:
 	@docker build -t $(LOKI_CURATOR_IMAGE_REPOSITORY):$(IMAGE_TAG) -t $(LOKI_CURATOR_IMAGE_REPOSITORY):latest -f Dockerfile --target curator .
 	@docker build -t $(TELEGRAF_IMAGE_REPOSITORY):$(IMAGE_TAG) -t $(TELEGRAF_IMAGE_REPOSITORY):latest -f Dockerfile --target telegraf .
 	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(EVENT_LOGGER_IMAGE_REPOSITORY):$(IMAGE_TAG) -t $(EVENT_LOGGER_IMAGE_REPOSITORY):latest -f Dockerfile --target event-logger .
+	@docker build -t $(TUNE2FS_IMAGE_REPOSITORY):$(IMAGE_TAG) -t $(TUNE2FS_IMAGE_REPOSITORY):latest -f Dockerfile --target tune2fs .
 
 .PHONY: docker-push
 docker-push:
@@ -72,6 +74,8 @@ docker-push:
 	@gcloud docker -- push $(TELEGRAF_IMAGE_REPOSITORY):$(IMAGE_TAG)
 	@if ! docker images $(EVENT_LOGGER_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(IMAGE_TAG); then echo "$(EVENT_LOGGER_IMAGE_REPOSITORY) version $(IMAGE_TAG) is not yet built. Please run 'make docker-images'"; false; fi
 	@gcloud docker -- push $(EVENT_LOGGER_IMAGE_REPOSITORY):$(IMAGE_TAG)
+	@if ! docker images $(TUNE2FS_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(IMAGE_TAG); then echo "$(TUNE2FS_IMAGE_REPOSITORY) version $(IMAGE_TAG) is not yet built. Please run 'make docker-images'"; false; fi
+	@gcloud docker -- push $(TUNE2FS_IMAGE_REPOSITORY):$(IMAGE_TAG)
 
 .PHONY: revendor
 revendor:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/logging
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
With this PR it introduces an image containing the bare minimum of libs for `tunef2s` to work alongside `lsblk` and `awk`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Build an image containing the bare minimum of libs for `tunef2s` to work alongside `lsblk` and `awk`.
```
