### PR TITLE
Replace lsblk with mount in tune2fs image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ CMD [ "/usr/bin/telegraf"]
 #############      tune2fs-builder       #############
 FROM alpine:3.17.2 as tune2fs-builder
 
-RUN apk add --update bash e2fsprogs-extra util-linux gawk && \
+RUN apk add --update bash e2fsprogs-extra mount gawk && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume
@@ -117,10 +117,9 @@ RUN mkdir -p ./lib ./usr/bin/ ./bin ./etc/bash ./usr/lib/bash ./usr/sbin/ ./etc/
     && cp -d /usr/bin/gawk ./usr/bin                                        && echo "package gawk" \
     && cp -d /lib/ld-musl-* ./lib                                           && echo "package musl" \
     && cp -d /lib/libc.musl-* ./lib                                         && echo "package musl" \
-    && cp -d /lib/libblkid.so.* ./lib                                       && echo "package util-linux" \
-    && cp -d /lib/libmount.so.* ./lib                                       && echo "package util-linux" \
-    && cp -d /lib/libsmartcols.so.* ./lib                                   && echo "package util-linux" \
-    && cp -d /bin/lsblk ./bin                                               && echo "package util-linux" \
+    && cp -d /lib/libmount.so.* ./lib                                       && echo "package mount" \
+    && cp -d /lib/libblkid.so.* ./lib                                       && echo "package mount" \
+    && cp -d /bin/mount ./bin                                               && echo "package mount" \
     && cp -d -r /etc/terminfo/* ./etc/terminfo                              && echo "package ncurses-terminfo-base" \
     && cp -d /usr/lib/libformw.so.* ./usr/lib                               && echo "package ncurses-libs" \
     && cp -d /usr/lib/libmenuw.so.* ./usr/lib                               && echo "package ncurses-libs" \
@@ -135,7 +134,7 @@ RUN mkdir -p ./lib ./usr/bin/ ./bin ./etc/bash ./usr/lib/bash ./usr/sbin/ ./etc/
     && cp -d /lib/libcom_err.so.* ./lib                                     && echo "package e2fsprogs-extra" \
     && cp -d /lib/libuuid.so.* ./lib                                        && echo "package e2fsprogs-extra" \
     && cp -d /lib/libe2p.so.* ./lib                                         && echo "package e2fsprogs-extra" \
-    && cp -d /usr/sbin/tune2fs ./usr/sbin                                 && echo "package e2fsprogs-extra"
+    && cp -d /usr/sbin/tune2fs ./usr/sbin                                   && echo "package e2fsprogs-extra"
 
 #############      tune2fs       #############
 FROM scratch AS tune2fs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement 
/area logging

**What this PR does / why we need it**:
With this PR we replace `lsblk` with `mount`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Replace `lsblk` with `mount` in the `tune2fs` image. 
```
