### PR TITLE
Preserve fluent-bit dynamic host suffixes for running shoots

### DIFF
--- a/cmd/fluent-bit-loki-plugin/out_loki.go
+++ b/cmd/fluent-bit-loki-plugin/out_loki.go
@@ -61,11 +61,11 @@ func init() {
 		}
 	}()
 
-	kubernetesCleint, err := getInclusterKubernetsClient()
+	kubernetesClient, err := getInclusterKubernetsClient()
 	if err != nil {
 		panic(err)
 	}
-	kubeInformerFactory := gardeninternalcoreinformers.NewSharedInformerFactory(kubernetesCleint, time.Second*30)
+	kubeInformerFactory := gardeninternalcoreinformers.NewSharedInformerFactory(kubernetesClient, time.Second*30)
 	informer = kubeInformerFactory.Extensions().V1alpha1().Clusters().Informer()
 	informerStopChan = make(chan struct{})
 	kubeInformerFactory.Start(informerStopChan)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,7 @@ const (
 	DefaultKubernetesMetadataTagPrefix = "kubernetes\\.var\\.log\\.containers"
 )
 
-// Config holds all of the needet properties of the loki output plugin
+// Config holds all of the needed properties of the loki output plugin
 type Config struct {
 	ClientConfig     ClientConfig
 	ControllerConfig ControllerConfig

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -70,8 +70,12 @@ func (ctl *controller) newControllerClient(clientConf *config.Config) (Controlle
 	return c, nil
 }
 
-func (ctl *controller) createControllerClient(clusterName string, shoot *gardenercorev1beta1.Shoot) {
-	clientConf := ctl.getClientConfig(clusterName)
+// TODO (nickytd) The checkTargetLoggingBackend parameter is only used to reckognize initial start of the cluster
+// informer and propagate further down to getClientConfig if this is an add callback or update callback.
+// Once loki to vali migration is done then we shall revert the original state and remove this parameter.
+func (ctl *controller) createControllerClient(clusterName string, shoot *gardenercorev1beta1.Shoot,
+	checkTargetLoggingBackend bool) {
+	clientConf := ctl.getClientConfig(clusterName, checkTargetLoggingBackend)
 	if clientConf == nil {
 		return
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area logging
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
In this PR we introduce a check toward running shoots logging stack to verify if we want to preserve the target suffix in the fluent-bit output plugins. This is needed to preserve running clusters from change in the output plugin configuration. Once the clusters are reconciled the targets are calculated to the default values and suffixes are pointing to the reconciled logging target.
The feature shall be removed after the migration from loki to vali.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
  Preserves loki based stacks from modification in the fluent-bit. Once the clusters are reconciled the fluent-bits output is recalculated.
```
