### PR TITLE
bump up golang image build version from 1.20.2 to 1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.20.2 AS plugin-builder
+FROM golang:1.20.4 AS plugin-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -22,7 +22,7 @@ WORKDIR /
 CMD /bin/cp /source/plugins/. /plugins
 
 #############      image-builder       #############
-FROM golang:1.20.2 AS image-builder
+FROM golang:1.20.4 AS image-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -51,7 +51,7 @@ WORKDIR /
 ENTRYPOINT [ "/event-logger" ]
 
 #############      telegraf-builder       #############
-FROM golang:1.20.2 AS telegraf-builder
+FROM golang:1.20.4 AS telegraf-builder
 
 RUN git clone https://github.com/influxdata/telegraf.git
 WORKDIR /go/telegraf


### PR DESCRIPTION
/kind enhancement
/area logging

This PR bumps up the golang container build images from 1.20.2 to 1.20.4 fixing number of CVE issues.
```other operator
Updated golang container image build version to 1.20.4
```
