### PR TITLE
Fix build variables propagation in fluent bit plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ EFFECTIVE_VERSION                          := $(VERSION)-$(shell git rev-parse H
 PARALLEL_E2E_TESTS                         := 1
 DOCKER_BUILD_PLATFORM                      ?= linux/amd64,linux/arm64
 
+LD_FLAGS                                   :=$(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
 BUILD_PLATFORM                             :=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 BUILD_ARCH                                 :=$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
@@ -54,17 +55,18 @@ KIND_VERSION                               ?= v0.18.0
 
 .PHONY: plugin
 plugin:
-	go build -mod=vendor -buildmode=c-shared -o build/out_vali.so ./cmd/fluent-bit-vali-plugin
+	@go build -mod=vendor -buildmode=c-shared -o $(REPO_ROOT)/build/out_vali.so \
+	  -ldflags="$(LD_FLAGS)" ./cmd/fluent-bit-vali-plugin
 
 .PHONY: curator
 curator:
-	CGO_ENABLED=0 GO111MODULE=on \
-	  go build -mod=vendor -o build/curator ./cmd/vali-curator
+	@CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o $(REPO_ROOT)/build/curator \
+	  -ldflags="$(LD_FLAGS)" ./cmd/vali-curator
 
 .PHONY: event-logger
 event-logger:
-	CGO_ENABLED=0 GO111MODULE=on \
-	  go build -mod=vendor -o $(REPO_ROOT)/build/event-logger $(REPO_ROOT)/cmd/event-logger
+	@CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o $(REPO_ROOT)/build/event-logger \
+	  -ldflags="$(LD_FLAGS)" $(REPO_ROOT)/cmd/event-logger
 
 .PHONY: build
 build: plugin

--- a/cmd/fluent-bit-vali-plugin/out_vali.go
+++ b/cmd/fluent-bit-vali-plugin/out_vali.go
@@ -30,10 +30,10 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/version"
 	"github.com/weaveworks/common/logging"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/version"
 )
 
 var (
@@ -110,7 +110,9 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	id := len(plugins)
 	logger := log.With(newLogger(conf.LogLevel), "ts", log.DefaultTimestampUTC, "id", id)
 
-	level.Info(logger).Log("[flb-go]", "Starting fluent-bit-go-vali", "version", version.Info())
+	level.Info(logger).Log("[flb-go]", "Starting fluent-bit-go-vali",
+		"version", version.Get().GitVersion,
+		"revision", version.Get().GitCommit)
 	paramLogger := log.With(logger, "[flb-go]", "provided parameter")
 	level.Info(paramLogger).Log("URL", conf.ClientConfig.CredativValiConfig.URL)
 	level.Info(paramLogger).Log("TenantID", conf.ClientConfig.CredativValiConfig.TenantID)

--- a/hack/.includes.sh
+++ b/hack/.includes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+repo_root="$(readlink -f $(dirname ${0})/..)"
+gardener=$(grep "github.com/gardener/gardener" $repo_root/go.mod |cut -d " " -f2)
+
+
+function __catch() {
+  local cmd="${1:-}"
+  echo
+  echo "errexit $cmd on line $(caller)" >&2
+}
+trap '__catch "${BASH_COMMAND}"' ERR
+
+function __check_executables {  
+  # required execs
+  execs=(make docker)
+  for ex in ${execs[@]}; do
+    if ! command -v "$ex" &> /dev/null ; then echo "$ex is required"; return 1; fi  
+  done
+  return 0
+}
+
+__check_executables
+
+# fetch yq in tools if not present
+if [[ ! -f "$repo_root/tools/yq" ]]; then
+  make -C $repo_root "$repo_root/tools/yq" 
+fi
+
+# fetch kind in tools if not present
+if [[ ! -f "$repo_root/tools/kind" ]]; then
+  make -C $repo_root "$repo_root/tools/kind" 
+fi

--- a/hack/docker-image-build.sh
+++ b/hack/docker-image-build.sh
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-dir=$(dirname $0)
+dir="$(dirname "$0")"
+
+set -o nounset #catch and prevent errors caused by the use of unset variables.
+set -o pipefail #exit with the exit code of the first error
+set -o errexit #exits immediately if any command in a script exits with a non-zero status
+
+source "$dir/.includes.sh"
 
 echo "> Docker build"
 

--- a/hack/docker-image-push.sh
+++ b/hack/docker-image-push.sh
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-dir=$(dirname $0)
+dir="$(dirname "$0")"
+
+set -o nounset #catch and prevent errors caused by the use of unset variables.
+set -o pipefail #exit with the exit code of the first error
+set -o errexit #exits immediately if any command in a script exits with a non-zero status
+
+source "$dir/.includes.sh"
 
 echo "> Docker image push"
 

--- a/hack/fetch-gardener.sh
+++ b/hack/fetch-gardener.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+dir="$(dirname "$0")"
+
+set -o errexit #exits immediately if any command in a script exits with a non-zero status
+
+source "$dir/.includes.sh"
+
+echo "REPO_ROOT ${repo_root}"
+if [[ ! -d "$repo_root/gardener" ]]; then
+  # use gardener/gardener version defined at .includes.sh ${gardener}
+  echo "fetch https://github.com/gardener/gardener.git ${gardener}"
+  git clone --depth 1 --branch ${gardener} https://github.com/gardener/gardener.git > /dev/null 2>&1
+fi

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -18,7 +18,7 @@ set -e
 
 PACKAGE_PATH="${1:-k8s.io/component-base}"
 VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
-PROGRAM_NAME="${3:-Gardener}"
+PROGRAM_NAME="${3:-Gardener_Logging}"
 VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
 VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
 

--- a/hack/load-container-images.sh
+++ b/hack/load-container-images.sh
@@ -23,8 +23,8 @@ $repo_root/tools/kind load docker-image telegraf-iptables:$version  --name garde
 $repo_root/tools/kind load docker-image tune2fs:$version  --name gardener-local
 $repo_root/tools/kind load docker-image event-logger:$version       --name gardener-local
 
-# Check to see if the gardenr repo is already fetched
-[[ ! -d "$repo_root/gardener" ]] && echo "fetch gardener repo in $repo_root"
+# Fetch the gardener repo
+[[ ! -d "$repo_root/gardener" ]] && "$dir/fetch-gardener.sh"
 
 # Change the image of the loggings in the fetched gardener repo
 target="$repo_root/gardener/charts/images.yaml"

--- a/hack/load-container-images.sh
+++ b/hack/load-container-images.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+dir="$(dirname "$0")"
+
+set -o nounset #catch and prevent errors caused by the use of unset variables.
+set -o pipefail #exit with the exit code of the first error
+set -o errexit #exits immediately if any command in a script exits with a non-zero status
+
+source "$dir/.includes.sh"
+
+# Make local images with uniq tags
+version=$(git rev-parse HEAD) # Get the hash of the current commit
+docker tag eu.gcr.io/gardener-project/gardener/fluent-bit-to-vali:latest fluent-bit-to-vali:$version
+docker tag eu.gcr.io/gardener-project/gardener/vali-curator:latest       vali-curator:$version
+docker tag eu.gcr.io/gardener-project/gardener/telegraf-iptables:latest  telegraf-iptables:$version
+docker tag eu.gcr.io/gardener-project/gardener/tune2fs:latest            tune2fs:$version
+docker tag eu.gcr.io/gardener-project/gardener/event-logger:latest       event-logger:$version
+
+# Load the images into the Kind cluster.
+$repo_root/tools/kind load docker-image fluent-bit-to-vali:$version --name gardener-local
+$repo_root/tools/kind load docker-image vali-curator:$version       --name gardener-local
+$repo_root/tools/kind load docker-image telegraf-iptables:$version  --name gardener-local
+$repo_root/tools/kind load docker-image tune2fs:$version  --name gardener-local
+$repo_root/tools/kind load docker-image event-logger:$version       --name gardener-local
+
+# Check to see if the gardenr repo is already fetched
+[[ ! -d "$repo_root/gardener" ]] && echo "fetch gardener repo in $repo_root"
+
+# Change the image of the loggings in the fetched gardener repo
+target="$repo_root/gardener/charts/images.yaml"
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"event-logger\") | .repository) |= \"docker.io/library/event-logger\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"event-logger\") | .tag) |= \"$version\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"fluent-bit-plugin-installer\") | .repository) |= \"docker.io/library/fluent-bit-to-vali\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"fluent-bit-plugin-installer\") | .tag) |= \"$version\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"vali-curator\") | .repository) |= \"docker.io/library/vali-curator\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"vali-curator\") | .tag) |= \"$version\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"telegraf\") | .repository) |= \"docker.io/library/telegraf-iptables\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"telegraf\") | .tag) |= \"$version\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"tune2fs\") | .repository) |= \"docker.io/library/tune2fs\"" $target
+$repo_root/tools/yq -i e "(.images[] | select(.name == \"tune2fs\") | .tag) |= \"$version\"" $target

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -8,12 +8,8 @@ set -o errexit #exits immediately if any command in a script exits with a non-ze
 
 source "$dir/.includes.sh"
 
-echo "REPO_ROOT ${repo_root}"
-if [[ ! -d "$repo_root/gardener" ]]; then
-  # use gardener/gardener version defined at .includes.sh ${gardener}
-  echo "fetch https://github.com/gardener/gardener.git ${gardener}"
-  git clone --depth 1 --branch ${gardener} https://github.com/gardener/gardener.git > /dev/null 2>&1
-fi
+# Fetch gardener repo
+source "$dir/fetch-gardener.sh"
 
 # Start Kind cluster
 make -C "$repo_root/gardener" kind-down # in case the test is run twice somehow skipping trap

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -1,33 +1,26 @@
 #!/usr/bin/env bash
 
+dir="$(dirname "$0")"
+
 set -o nounset #catch and prevent errors caused by the use of unset variables.
 set -o pipefail #exit with the exit code of the first error
 set -o errexit #exits immediately if any command in a script exits with a non-zero status
 
-function __catch() {
-  local cmd="${1:-}"
-  echo
-  echo "errexit $cmd on line $(caller)" >&2
-}
-trap '__catch "${BASH_COMMAND}"' ERR
+source "$dir/.includes.sh"
 
-
-repo_root="$(readlink -f $(dirname ${0})/..)"
 echo "REPO_ROOT ${repo_root}"
 if [[ ! -d "$repo_root/gardener" ]]; then
-  # use gardener/gardener v1.71.2
-  echo "fetch https://github.com/gardener/gardener.git v1.71.2"
-  git clone --depth 1 --branch v1.71.2 https://github.com/gardener/gardener.git > /dev/null 2>&1
+  # use gardener/gardener version defined at .includes.sh ${gardener}
+  echo "fetch https://github.com/gardener/gardener.git ${gardener}"
+  git clone --depth 1 --branch ${gardener} https://github.com/gardener/gardener.git > /dev/null 2>&1
 fi
 
 # Start Kind cluster
-cd "$repo_root/gardener"
-make kind-down # in case the test is run twice somehow skipping trap
-make kind-up
+make -C "$repo_root/gardener" kind-down # in case the test is run twice somehow skipping trap
+make -C "$repo_root/gardener" kind-up
 
-trap '{
-  cd "$repo_root/gardener"
-  make kind-down
+trap '{  
+  make -C "$repo_root/gardener" kind-down
 }' EXIT
 
 # make shoot domains accessible to test
@@ -40,41 +33,13 @@ if ! grep -q "127.0.0.1 api.local.local.internal.local.gardener.cloud" /etc/host
 fi
 
 # Build docker images
-cd $repo_root
-make docker-images
+make -C $repo_root docker-images
 
-# # Make local images with uniq tags
-version=$(git rev-parse HEAD) # Get the hash of the current commit
-docker tag eu.gcr.io/gardener-project/gardener/fluent-bit-to-vali:latest fluent-bit-to-vali:$version
-docker tag eu.gcr.io/gardener-project/gardener/vali-curator:latest       vali-curator:$version
-docker tag eu.gcr.io/gardener-project/gardener/telegraf-iptables:latest  telegraf-iptables:$version
-docker tag eu.gcr.io/gardener-project/gardener/tune2fs:latest            tune2fs:$version
-docker tag eu.gcr.io/gardener-project/gardener/event-logger:latest       event-logger:$version
-
-# Load the images into the Kind cluster.
-kind load docker-image fluent-bit-to-vali:$version --name gardener-local
-kind load docker-image vali-curator:$version       --name gardener-local
-kind load docker-image telegraf-iptables:$version  --name gardener-local
-kind load docker-image tune2fs:$version  --name gardener-local
-kind load docker-image event-logger:$version       --name gardener-local
-
-# Change the image of the loggings in the gardener repo
-cd "$repo_root/gardener"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"event-logger\") | .repository) |= \"docker.io/library/event-logger\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"event-logger\") | .tag) |= \"$version\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"fluent-bit-plugin-installer\") | .repository) |= \"docker.io/library/fluent-bit-to-vali\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"fluent-bit-plugin-installer\") | .tag) |= \"$version\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"vali-curator\") | .repository) |= \"docker.io/library/vali-curator\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"vali-curator\") | .tag) |= \"$version\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"telegraf\") | .repository) |= \"docker.io/library/telegraf-iptables\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"telegraf\") | .tag) |= \"$version\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"tune2fs\") | .repository) |= \"docker.io/library/tune2fs\"" "charts/images.yaml"
-$repo_root/tools/yq -i e "(.images[] | select(.name == \"tune2fs\") | .tag) |= \"$version\"" "charts/images.yaml"
+# Load container images in the gardener-local kind cluster
+source $dir/load-container-images.sh
 
 export KUBECONFIG=$repo_root/gardener/example/gardener-local/kind/local/kubeconfig
-make gardener-up
-
-cd $repo_root
+make -C $repo_root/gardener gardener-up
 
 # reduce flakiness in contended pipelines
 export GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=5s
@@ -86,5 +51,4 @@ export GOMEGA_DEFAULT_CONSISTENTLY_POLLING_INTERVAL=200ms
 
 GO111MODULE=on $repo_root/tools/ginkgo run --timeout=1h --v --show-node-events --progress "$@"
 
-cd "$repo_root/gardener"
-make gardener-down
+make -C "$repo_root/gardener" gardener-down


### PR DESCRIPTION
/area logging
/kind enhancement

This PR brings following fixes and improvements:

- fix version and revision build variables propagation in fluent-bit plugin
- refactors build & test scripts to facilitate local-dev scenarios

```other operator
Now git revision and commit ids are properly propagated through build variables. These are showed in the fluent-bit plugin logs during start.
```
