### PR TITLE
update alpine base image to 3.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,9 @@ WORKDIR /go/telegraf
 RUN CGO_ENABLED=0 make build
 
 #############      iptables-builder       #############
-FROM alpine:3.17.2 as iptables-builder
+FROM alpine:3.18.0 as iptables-builder
 
-RUN apk add --update bash sudo iptables && \
+RUN apk add --update bash sudo iptables ncurses-libs libmnl && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume
@@ -103,9 +103,9 @@ COPY --from=telegraf-builder /go/telegraf/telegraf /usr/bin/telegraf
 CMD [ "/usr/bin/telegraf"]
 
 #############      tune2fs-builder       #############
-FROM alpine:3.17.2 as tune2fs-builder
+FROM alpine:3.18.0 as tune2fs-builder
 
-RUN apk add --update bash e2fsprogs-extra mount gawk && \
+RUN apk add --update bash e2fsprogs-extra mount gawk ncurses-libs && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume


### PR DESCRIPTION
/area logging
/kind task

This PR bumps up the alpine base image from 3.17.2 to 3.18.0. 

```other operator
Base image on `telegraf` and `tune2fs` is upgraded from 3.17.2 to 3.18.0
```
