### PR TITLE
Set responsibles

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -27,6 +27,10 @@ logging:
                 integrity_requirement: 'none'
                 availability_requirement: 'none'
                 comment: no data is stored or processed by the installer
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubTeam'
+                teamname: 'gardener/logging-maintainers'
           vali-curator:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/vali-curator'
@@ -41,6 +45,10 @@ logging:
                 confidentiality_requirement: 'none'
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubTeam'
+                teamname: 'gardener/logging-maintainers'
           telegraf-iptables:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/telegraf-iptables'
@@ -56,6 +64,10 @@ logging:
                 integrity_requirement: 'none'
                 availability_requirement: 'none'
                 comment: telegraf is not accessible from outside the seed cluster and does not interact with confidential data
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubTeam'
+                teamname: 'gardener/logging-maintainers'
           event-logger:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/event-logger'
@@ -70,6 +82,10 @@ logging:
                 confidentiality_requirement: 'high'
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubTeam'
+                teamname: 'gardener/logging-maintainers'
           tune2fs:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/tune2fs'
@@ -84,6 +100,10 @@ logging:
                 confidentiality_requirement: 'none'
                 integrity_requirement: 'none'
                 availability_requirement: 'low'
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubTeam'
+                teamname: 'gardener/logging-maintainers'
     steps:
       verify:
         image: 'golang:1.20.4'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
Sets 'cloud.gardener.cnudie/responsibles' label

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
