### PR TITLE
switch GCR -> Artifact-Registry 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,6 +4,8 @@ logging:
       version:
         preprocess:
           'inject-commit-hash'
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -11,7 +13,7 @@ logging:
         - linux/arm64
         dockerimages:
           fluent-bit-to-vali:
-            image: 'eu.gcr.io/gardener-project/gardener/fluent-bit-to-vali'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/fluent-bit-to-vali
             dockerfile: './Dockerfile'
             target: fluent-bit-plugin
             resource_labels:
@@ -29,7 +31,7 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           vali-curator:
-            image: 'eu.gcr.io/gardener-project/gardener/vali-curator'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/vali-curator
             dockerfile: './Dockerfile'
             target: curator
             resource_labels:
@@ -46,7 +48,7 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           telegraf-iptables:
-            image: 'eu.gcr.io/gardener-project/gardener/telegraf-iptables'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/telegraf-iptables
             dockerfile: './Dockerfile'
             target: telegraf
             resource_labels:
@@ -64,7 +66,7 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           event-logger:
-            image: 'eu.gcr.io/gardener-project/gardener/event-logger'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/event-logger
             dockerfile: './Dockerfile'
             target: event-logger
             resource_labels:
@@ -81,7 +83,7 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           tune2fs:
-            image: 'eu.gcr.io/gardener-project/gardener/tune2fs'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/tune2fs
             dockerfile: './Dockerfile'
             target: tune2fs
             resource_labels:
@@ -100,10 +102,9 @@ logging:
     steps:
       verify:
         image: 'golang:1.20.4'
+
   jobs:
-    head-update:
-      traits:
-        component_descriptor: ~
+    head-update: ~
     pull-request:
       traits:
         pull-request: ~
@@ -111,9 +112,22 @@ logging:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            fluent-bit-to-vali:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
+            vali-curator:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
+            telegraf-iptables:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
+            event-logger:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
+            tune2fs:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
         release:
           nextversion: 'bump_patch'
-        component_descriptor: ~
         slack:
           default_channel: "internal_scp_workspace"
           channel_cfgs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 logging:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
@@ -13,7 +11,6 @@ logging:
         - linux/arm64
         dockerimages:
           fluent-bit-to-vali:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/fluent-bit-to-vali'
             dockerfile: './Dockerfile'
             target: fluent-bit-plugin
@@ -32,7 +29,6 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           vali-curator:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/vali-curator'
             dockerfile: './Dockerfile'
             target: curator
@@ -50,7 +46,6 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           telegraf-iptables:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/telegraf-iptables'
             dockerfile: './Dockerfile'
             target: telegraf
@@ -69,7 +64,6 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           event-logger:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/event-logger'
             dockerfile: './Dockerfile'
             target: event-logger
@@ -87,7 +81,6 @@ logging:
               - type: 'githubTeam'
                 teamname: 'gardener/logging-maintainers'
           tune2fs:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/tune2fs'
             dockerfile: './Dockerfile'
             target: tune2fs

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 REPO_ROOT                                  := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSION                                    := $(shell cat VERSION)
-REGISTRY                                   ?= eu.gcr.io/gardener-project/gardener
+REGISTRY                                   ?= europe-docker.pkg.dev/gardener-project/public/gardener
 FLUENT_BIT_TO_VALI_IMAGE_REPOSITORY        := $(REGISTRY)/fluent-bit-to-vali
 VALI_CURATOR_IMAGE_REPOSITORY              := $(REGISTRY)/vali-curator
 TELEGRAF_IMAGE_REPOSITORY                  := $(REGISTRY)/telegraf-iptables

--- a/hack/load-container-images.sh
+++ b/hack/load-container-images.sh
@@ -34,7 +34,7 @@ target="$repo_root/gardener/charts/images.yaml"
 
 for img in "${images[@]}"; do
   # tag "latest "container image if exists
-  container_image="eu.gcr.io/gardener-project/gardener/${img}:latest"
+  container_image="europe-docker.pkg.dev/gardener-project/public/gardener/${img}:latest"
   if [[ "exists" == $(__check_container_image ${container_image}) ]]; then
     docker tag ${container_image} ${img}:${version}
   else

--- a/hack/update_chart_images.sh
+++ b/hack/update_chart_images.sh
@@ -9,7 +9,7 @@ target="$repo_root/gardener/charts/images.yaml"
 
 fluent_regex="^.*fluent-bit-to-vali$"
 function __update_fluent_skaffold_images() {
-  local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/fluent-bit-to-vali")}"
+  local registry="${1:-$(echo "localhost:5001/europe_docker_pkg_dev_gardener-project_gardener/fluent-bit-to-vali")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
 
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"fluent-bit-plugin-installer\") | .repository) |=\"${registry}\"" $target
@@ -18,7 +18,7 @@ function __update_fluent_skaffold_images() {
 
 event_regex="^.*event-logger$"
 function __update_event_skaffold_images() {
-  local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/event-logger")}"
+  local registry="${1:-$(echo "localhost:5001/europe_docker_pkg_dev_gardener-project_gardener/event-logger")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
 
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"event-logger\") | .repository) |=\"${registry}\"" $target
@@ -27,7 +27,7 @@ function __update_event_skaffold_images() {
 
 curator_regex="^.*vali-curator$"
 function __update_curator_skaffold_images() {
-  local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/vali-curator")}"
+  local registry="${1:-$(echo "localhost:5001/europe_docker_pkg_dev_gardener-project_gardener/vali-curator")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
 
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"vali-curator\") | .repository) |=\"${registry}\"" $target
@@ -36,7 +36,7 @@ function __update_curator_skaffold_images() {
 
 telegraf_regex="^.*telegraf-iptables$"
 function __update_telegraf_skaffold_images() {
-  local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/telegraf-iptables")}"
+  local registry="${1:-$(echo "localhost:5001/europe_docker_pkg_dev_gardener-project_gardener/telegraf-iptables")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
 
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"telegraf\") | .repository) |=\"${registry}\"" $target
@@ -45,7 +45,7 @@ function __update_telegraf_skaffold_images() {
 
 tune2fs_regex="^.*tune2fs$"
 function __update_tune2fs_skaffold_images() {
-  local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/tune2fs")}"
+  local registry="${1:-$(echo "localhost:5001/europe_docker_pkg_dev_gardener-project_gardener/tune2fs")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
 
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"tune2fs\") | .repository) |=\"${registry}\"" $target

--- a/hack/update_chart_images.sh
+++ b/hack/update_chart_images.sh
@@ -4,23 +4,23 @@ dir="$(dirname "$0")"
 
 source "$dir/.includes.sh"
 
-# Change the image of the loggings in the fetched gardener repo  
+# Change the image of the loggings in the fetched gardener repo
 target="$repo_root/gardener/charts/images.yaml"
 
 fluent_regex="^.*fluent-bit-to-vali$"
 function __update_fluent_skaffold_images() {
   local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/fluent-bit-to-vali")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
-  
+
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"fluent-bit-plugin-installer\") | .repository) |=\"${registry}\"" $target
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"fluent-bit-plugin-installer\") | .tag) |= \"$version\"" $target
-} 
+}
 
 event_regex="^.*event-logger$"
 function __update_event_skaffold_images() {
   local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/event-logger")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
-  
+
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"event-logger\") | .repository) |=\"${registry}\"" $target
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"event-logger\") | .tag) |= \"$version\"" $target
 }
@@ -29,7 +29,7 @@ curator_regex="^.*vali-curator$"
 function __update_curator_skaffold_images() {
   local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/vali-curator")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
-  
+
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"vali-curator\") | .repository) |=\"${registry}\"" $target
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"vali-curator\") | .tag) |= \"$version\"" $target
 }
@@ -38,7 +38,7 @@ telegraf_regex="^.*telegraf-iptables$"
 function __update_telegraf_skaffold_images() {
   local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/telegraf-iptables")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
-  
+
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"telegraf\") | .repository) |=\"${registry}\"" $target
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"telegraf\") | .tag) |= \"$version\"" $target
 }
@@ -47,33 +47,33 @@ tune2fs_regex="^.*tune2fs$"
 function __update_tune2fs_skaffold_images() {
   local registry="${1:-$(echo "localhost:5001/eu_gcr_io_gardener-project_gardener/tune2fs")}"
   local version="${2:-$(git rev-parse HEAD 2>/dev/null || echo "latest")}"
-  
+
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"tune2fs\") | .repository) |=\"${registry}\"" $target
   $repo_root/tools/yq -i e "(.images[] | select(.name == \"tune2fs\") | .tag) |= \"$version\"" $target
 }
 
 
-if [[ ! -z "$1" ]] && [[ "$1" =~ $fluent_regex ]]; then   
+if [[ ! -z "$1" ]] && [[ "$1" =~ $fluent_regex ]]; then
   __update_fluent_skaffold_images "$@"
   exit 0
-fi  
+fi
 
-if [[ ! -z "$1" ]] && [[ "$1" =~ $event_regex ]]; then   
+if [[ ! -z "$1" ]] && [[ "$1" =~ $event_regex ]]; then
   __update_event_skaffold_images "$@"
   exit 0
-fi  
+fi
 
-if [[ ! -z "$1" ]] && [[ "$1" =~ $curator_regex ]]; then   
+if [[ ! -z "$1" ]] && [[ "$1" =~ $curator_regex ]]; then
   __update_curator_skaffold_images "$@"
   exit 0
 fi
 
-if [[ ! -z "$1" ]] && [[ "$1" =~ $telegraf_regex ]]; then   
+if [[ ! -z "$1" ]] && [[ "$1" =~ $telegraf_regex ]]; then
   __update_telegraf_skaffold_images "$@"
   exit 0
-fi  
+fi
 
-if [[ ! -z "$1" ]] && [[ "$1" =~ $tune2fs_regex ]]; then   
+if [[ ! -z "$1" ]] && [[ "$1" =~ $tune2fs_regex ]]; then
   __update_tune2fs_skaffold_images "$@"
   exit 0
 fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -40,11 +40,11 @@ metadata:
   name: provider-local
 build:
   artifacts:
-    - image: eu.gcr.io/gardener-project/gardener/extensions/provider-local
+    - image: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/provider-local
       custom:
         buildCommand: |
-          docker pull -q eu.gcr.io/gardener-project/gardener/gardener-extension-provider-local:{{.GARDENER_VERSION}}
-          docker tag eu.gcr.io/gardener-project/gardener/gardener-extension-provider-local:{{.GARDENER_VERSION}} $IMAGE
+          docker pull -q europe-docker.pkg.dev/gardener-project/public/gardener/gardener-extension-provider-local:{{.GARDENER_VERSION}}
+          docker tag europe-docker.pkg.dev/gardener-project/public/gardener/gardener-extension-provider-local:{{.GARDENER_VERSION}} $IMAGE
           [ ! -z $PUSH_IMAGE ] && docker push $IMAGE
 resourceSelector:
   allow:
@@ -67,7 +67,7 @@ metadata:
   name: gardenlet
 build:
   artifacts:
-    - image: eu.gcr.io/gardener-project/gardener/fluent-bit-to-vali
+    - image: europe-docker.pkg.dev/gardener-project/public/gardener/fluent-bit-to-vali
       docker:
         target: fluent-bit-plugin
         cacheFrom:
@@ -92,7 +92,7 @@ deploy:
         imageVectorOverwrite: |
           images:
           - name: fluent-bit-plugin-installer
-            repository: '{{.IMAGE_REPO_eu_gcr_io_gardener_project_gardener_fluent_bit_to_vali}}'
-            tag: '{{.IMAGE_TAG_eu_gcr_io_gardener_project_gardener_fluent_bit_to_vali}}@{{.IMAGE_DIGEST_eu_gcr_io_gardener_project_gardener_fluent_bit_to_vali}}'
+            repository: '{{.IMAGE_REPO_europe_docker_pkg_dev_gardener_project_gardener_fluent_bit_to_vali}}'
+            tag: '{{.IMAGE_TAG_europe_docker_pkg_dev_gardener_project_gardener_fluent_bit_to_vali}}@{{.IMAGE_DIGEST_europe_docker_pkg_dev_gardener_project_gardener_fluent_bit_to_vali}}'
       createNamespace: true
       wait: true


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
