### PR TITLE
Bump up dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.20.4 AS plugin-builder
+FROM golang:1.21.6 AS plugin-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -21,7 +21,7 @@ WORKDIR /
 CMD /bin/cp /source/plugins/. /plugins
 
 #############      image-builder       #############
-FROM golang:1.20.4 AS image-builder
+FROM golang:1.21.6 AS image-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -50,7 +50,7 @@ WORKDIR /
 ENTRYPOINT [ "/event-logger" ]
 
 #############      telegraf-builder       #############
-FROM golang:1.20.4 AS telegraf-builder
+FROM golang:1.21.6 AS telegraf-builder
 RUN git clone --depth 1 --branch v1.26.0 https://github.com/influxdata/telegraf.git
 WORKDIR /go/telegraf
 RUN CGO_ENABLED=0 make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /go/telegraf
 RUN CGO_ENABLED=0 make build
 
 #############      iptables-builder       #############
-FROM alpine:3.18.0 as iptables-builder
+FROM alpine:3.19.0 as iptables-builder
 
 RUN apk add --update bash sudo iptables ncurses-libs libmnl && \
     rm -rf /var/cache/apk/*
@@ -82,9 +82,6 @@ RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables
     && cp -d /etc/ethertypes ./etc                                          && echo "package iptables" \
     && cp -d /sbin/iptables* ./sbin                                         && echo "package iptables" \
     && cp -d /sbin/xtables* ./sbin                                          && echo "package iptables" \
-    && cp -d /usr/lib/libip4* ./usr/lib                                     && echo "package iptables" \
-    && cp -d /usr/lib/libip6* ./usr/lib                                     && echo "package iptables" \
-    && cp -d /usr/lib/libipq* ./usr/lib                                     && echo "package iptables" \
     && cp -d /usr/lib/libxtables* ./usr/lib                                 && echo "package iptables" \
     && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables" \
     && cp -d /usr/lib/sudo/* ./usr/lib/sudo                                 && echo "package sudo" \
@@ -103,7 +100,7 @@ COPY --from=telegraf-builder /go/telegraf/telegraf /usr/bin/telegraf
 CMD [ "/usr/bin/telegraf"]
 
 #############      tune2fs-builder       #############
-FROM alpine:3.18.0 as tune2fs-builder
+FROM alpine:3.19.0 as tune2fs-builder
 
 RUN apk add --update bash e2fsprogs-extra mount gawk ncurses-libs && \
     rm -rf /var/cache/apk/*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/logging
 
-go 1.20
+go 1.21
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
/area logging

This PR upgrade project build dependencies:

- The alpine base image is upgraded from 3.18 to 3.19
- The golang is upgraded from 1.20.4 to 1.21.6
