### PR TITLE
Update golang build dependencies to 1.20.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.21.6 AS plugin-builder
+FROM golang:1.20.13 AS plugin-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -21,7 +21,7 @@ WORKDIR /
 CMD /bin/cp /source/plugins/. /plugins
 
 #############      image-builder       #############
-FROM golang:1.21.6 AS image-builder
+FROM golang:1.20.13 AS image-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -50,7 +50,7 @@ WORKDIR /
 ENTRYPOINT [ "/event-logger" ]
 
 #############      telegraf-builder       #############
-FROM golang:1.21.6 AS telegraf-builder
+FROM golang:1.20.13 AS telegraf-builder
 RUN git clone --depth 1 --branch v1.26.0 https://github.com/influxdata/telegraf.git
 WORKDIR /go/telegraf
 RUN CGO_ENABLED=0 make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/logging
 
-go 1.21
+go 1.20
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
/area logging


This PR updates golang build dependencies to 1.20.13.
Note: The current version of fluent-bit (v2.2.0) contains an older glibc version preventing for now moving to 1.21 golang version. Once the fluent-bit base image is upgraded to contain the latest glibc, then this plugin can be upgraded to build agains golang 1.21
