### PR TITLE
Revert plugin golang build dependencies to 1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.20.13 AS plugin-builder
+FROM golang:1.20.4 AS plugin-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .


### PR DESCRIPTION
/area logging

This PR reverts plugin golang dependency to 1.20.4. preventing fluent-bit starting issue
[error] [proxy] error opening plugin /fluent-bit/plugins/out_vali.so: '/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /fluent-bit/plugins/out_vali.so)'