### PR TITLE
Remove loki to vali migration code

### DIFF
--- a/cmd/fluent-bit-vali-plugin/out_vali.go
+++ b/cmd/fluent-bit-vali-plugin/out_vali.go
@@ -116,12 +116,14 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 
 	// numeric plugin ID, only used for user-facing purpose (logging, ...)
 	id := len(plugins)
-	logger := log.With(newLogger(conf.LogLevel), "ts", log.DefaultTimestampUTC, "id", id)
+	_logger := log.With(newLogger(conf.LogLevel), "ts", log.DefaultTimestampUTC, "id", id)
 
-	level.Info(logger).Log("[flb-go]", "Starting fluent-bit-go-vali",
+	_ = level.Info(_logger).Log(
+		"[flb-go]", "Starting fluent-bit-go-vali",
 		"version", version.Get().GitVersion,
-		"revision", version.Get().GitCommit)
-	paramLogger := log.With(logger, "[flb-go]", "provided parameter")
+		"revision", version.Get().GitCommit,
+	)
+	paramLogger := log.With(_logger, "[flb-go]", "provided parameter")
 	level.Info(paramLogger).Log("URL", conf.ClientConfig.CredativValiConfig.URL)
 	level.Info(paramLogger).Log("TenantID", conf.ClientConfig.CredativValiConfig.TenantID)
 	level.Info(paramLogger).Log("BatchWait", conf.ClientConfig.CredativValiConfig.BatchWait)
@@ -186,10 +188,10 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	level.Info(paramLogger).Log("SendLogsToDefaultClientWhenClusterIsInRestoreState", fmt.Sprintf("%+v", conf.ControllerConfig.DefaultControllerClientConfig.SendLogsWhenIsInRestoreState))
 	level.Info(paramLogger).Log("SendLogsToDefaultClientWhenClusterIsInMigrationState", fmt.Sprintf("%+v", conf.ControllerConfig.DefaultControllerClientConfig.SendLogsWhenIsInMigrationState))
 
-	plugin, err := valiplugin.NewPlugin(informer, conf, logger)
+	plugin, err := valiplugin.NewPlugin(informer, conf, _logger)
 	if err != nil {
 		metrics.Errors.WithLabelValues(metrics.ErrorNewPlugin).Inc()
-		level.Error(logger).Log("newPlugin", err)
+		level.Error(_logger).Log("newPlugin", err)
 		return output.FLB_ERROR
 	}
 
@@ -279,18 +281,18 @@ func FLBPluginExit() int {
 }
 
 func newLogger(logLevel logging.Level) log.Logger {
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = level.NewFilter(logger, logLevel.Gokit)
-	logger = log.With(logger, "caller", log.Caller(3))
-	return logger
+	_logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	_logger = level.NewFilter(_logger, logLevel.Gokit)
+	_logger = log.With(_logger, "caller", log.Caller(3))
+	return _logger
 }
 
 func getInclusterKubernetsClient() (gardenerclientsetversioned.Interface, error) {
-	config, err := rest.InClusterConfig()
+	c, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
 	}
-	return gardenerclientsetversioned.NewForConfig(config)
+	return gardenerclientsetversioned.NewForConfig(c)
 }
 
 func main() {}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,7 +29,7 @@ type Options struct {
 	PreservedLabels model.LabelSet
 }
 
-// NewClient creates a new client based on the fluentbit configuration.
+// NewClient creates a new client based on the fluent-bit configuration.
 func NewClient(cfg config.Config, logger log.Logger, options Options) (ValiClient, error) {
 	var (
 		ncf NewValiClientFunc

--- a/pkg/valiplugin/vali.go
+++ b/pkg/valiplugin/vali.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/gardener/logging/pkg/client"
 	"github.com/gardener/logging/pkg/config"
-	controller "github.com/gardener/logging/pkg/controller"
+	"github.com/gardener/logging/pkg/controller"
 	"github.com/gardener/logging/pkg/metrics"
 )
 
@@ -90,21 +90,21 @@ func NewPlugin(informer cache.SharedIndexInformer, cfg *config.Config, logger lo
 }
 
 // sendRecord send fluentbit records to vali as an entry.
-func (l *vali) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
+func (v *vali) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	records := toStringMap(r)
-	_ = level.Debug(l.logger).Log("msg", "processing records", "records", fluentBitRecords(records))
-	lbs := make(model.LabelSet, l.cfg.PluginConfig.LabelSetInitCapacity)
+	_ = level.Debug(v.logger).Log("msg", "processing records", "records", fluentBitRecords(records))
+	lbs := make(model.LabelSet, v.cfg.PluginConfig.LabelSetInitCapacity)
 
 	// Check if metadata is missing
-	if l.cfg.PluginConfig.KubernetesMetadata.FallbackToTagWhenMetadataIsMissing {
+	if v.cfg.PluginConfig.KubernetesMetadata.FallbackToTagWhenMetadataIsMissing {
 		if _, ok := records["kubernetes"]; !ok {
-			_ = level.Debug(l.logger).Log("msg", "kubernetes metadata is missing. Will try to extract it from the tag key", "tagKey", l.cfg.PluginConfig.KubernetesMetadata.TagKey, "records", fluentBitRecords(records))
-			err := extractKubernetesMetadataFromTag(records, l.cfg.PluginConfig.KubernetesMetadata.TagKey, l.extractKubernetesMetadataRegexp)
+			_ = level.Debug(v.logger).Log("msg", "kubernetes metadata is missing. Will try to extract it from the tag key", "tagKey", v.cfg.PluginConfig.KubernetesMetadata.TagKey, "records", fluentBitRecords(records))
+			err := extractKubernetesMetadataFromTag(records, v.cfg.PluginConfig.KubernetesMetadata.TagKey, v.extractKubernetesMetadataRegexp)
 			if err != nil {
 				metrics.Errors.WithLabelValues(metrics.ErrorCanNotExtractMetadataFromTag).Inc()
-				_ = level.Error(l.logger).Log("msg", err, "records", fluentBitRecords(records))
-				if l.cfg.PluginConfig.KubernetesMetadata.DropLogEntryWithoutK8sMetadata {
-					_ = level.Warn(l.logger).Log("msg", "kubernetes metadata is missing and the log entry will be dropped", "records", fluentBitRecords(records))
+				_ = level.Error(v.logger).Log("msg", err, "records", fluentBitRecords(records))
+				if v.cfg.PluginConfig.KubernetesMetadata.DropLogEntryWithoutK8sMetadata {
+					_ = level.Warn(v.logger).Log("msg", "kubernetes metadata is missing and the log entry will be dropped", "records", fluentBitRecords(records))
 					metrics.LogsWithoutMetadata.WithLabelValues(metrics.MissingMetadataType).Inc()
 					return nil
 				}
@@ -112,26 +112,26 @@ func (l *vali) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 		}
 	}
 
-	if l.cfg.PluginConfig.AutoKubernetesLabels {
+	if v.cfg.PluginConfig.AutoKubernetesLabels {
 		err := autoLabels(records, lbs)
 		if err != nil {
 			metrics.Errors.WithLabelValues(metrics.ErrorK8sLabelsNotFound).Inc()
-			_ = level.Error(l.logger).Log("msg", err.Error(), "records", fluentBitRecords(records))
+			_ = level.Error(v.logger).Log("msg", err.Error(), "records", fluentBitRecords(records))
 		}
 	}
 
-	if l.cfg.PluginConfig.LabelMap != nil {
-		mapLabels(records, l.cfg.PluginConfig.LabelMap, lbs)
+	if v.cfg.PluginConfig.LabelMap != nil {
+		mapLabels(records, v.cfg.PluginConfig.LabelMap, lbs)
 	} else {
-		lbs = extractLabels(records, l.cfg.PluginConfig.LabelKeys)
+		lbs = extractLabels(records, v.cfg.PluginConfig.LabelKeys)
 	}
 
-	dynamicHostName := getDynamicHostName(records, l.cfg.PluginConfig.DynamicHostPath)
+	dynamicHostName := getDynamicHostName(records, v.cfg.PluginConfig.DynamicHostPath)
 	host := dynamicHostName
-	if !l.isDynamicHost(host) {
+	if !v.isDynamicHost(host) {
 		host = "garden"
 	} else {
-		lbs = l.setDynamicTenant(records, lbs)
+		lbs = v.setDynamicTenant(records, lbs)
 	}
 
 	metrics.IncomingLogs.WithLabelValues(host).Inc()
@@ -141,47 +141,47 @@ func (l *vali) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	extractMultiTenantClientLabel(records, lbs)
 	removeMultiTenantClientLabel(records)
 
-	removeKeys(records, append(l.cfg.PluginConfig.LabelKeys, l.cfg.PluginConfig.RemoveKeys...))
+	removeKeys(records, append(v.cfg.PluginConfig.LabelKeys, v.cfg.PluginConfig.RemoveKeys...))
 	if len(records) == 0 {
-		_ = level.Info(l.logger).Log("host", dynamicHostName, "issue", "no records left after removing keys")
+		_ = level.Debug(v.logger).Log("host", dynamicHostName, "issue", "no records left after removing keys")
 		metrics.DroppedLogs.WithLabelValues(host).Inc()
 		return nil
 	}
 
-	client := l.getClient(dynamicHostName)
+	c := v.getClient(dynamicHostName)
 
-	if client == nil {
-		_ = level.Info(l.logger).Log("host", dynamicHostName, "issue", "could not find a client")
+	if c == nil {
+		_ = level.Info(v.logger).Log("host", dynamicHostName, "issue", "could not find a client")
 		metrics.DroppedLogs.WithLabelValues(host).Inc()
 		return nil
 	}
 
 	metrics.IncomingLogsWithEndpoint.WithLabelValues(host).Inc()
 
-	if err := l.addHostnameAsLabel(lbs); err != nil {
-		_ = level.Warn(l.logger).Log("msg", err)
+	if err := v.addHostnameAsLabel(lbs); err != nil {
+		_ = level.Warn(v.logger).Log("msg", err)
 	}
 
-	if l.cfg.PluginConfig.DropSingleKey && len(records) == 1 {
-		for _, v := range records {
-			err := l.send(client, lbs, ts, fmt.Sprintf("%v", v))
+	if v.cfg.PluginConfig.DropSingleKey && len(records) == 1 {
+		for _, record := range records {
+			err := v.send(c, lbs, ts, fmt.Sprintf("%v", record))
 			if err != nil {
-				_ = level.Error(l.logger).Log("msg", "error sending record to Vali", "host", dynamicHostName, "error", err)
+				_ = level.Error(v.logger).Log("msg", "error sending record to Vali", "host", dynamicHostName, "error", err)
 				metrics.Errors.WithLabelValues(metrics.ErrorSendRecordToVali).Inc()
 			}
 			return err
 		}
 	}
 
-	line, err := createLine(records, l.cfg.PluginConfig.LineFormat)
+	line, err := createLine(records, v.cfg.PluginConfig.LineFormat)
 	if err != nil {
 		metrics.Errors.WithLabelValues(metrics.ErrorCreateLine).Inc()
 		return fmt.Errorf("error creating line: %v", err)
 	}
 
-	err = l.send(client, lbs, ts, line)
+	err = v.send(c, lbs, ts, line)
 	if err != nil {
-		_ = level.Error(l.logger).Log("msg", "error sending record to Vali", "host", dynamicHostName, "error", err)
+		_ = level.Error(v.logger).Log("msg", "error sending record to Vali", "host", dynamicHostName, "error", err)
 		metrics.Errors.WithLabelValues(metrics.ErrorSendRecordToVali).Inc()
 
 		return err
@@ -190,61 +190,61 @@ func (l *vali) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	return nil
 }
 
-func (l *vali) Close() {
-	l.defaultClient.Stop()
-	if l.controller != nil {
-		l.controller.Stop()
+func (v *vali) Close() {
+	v.defaultClient.Stop()
+	if v.controller != nil {
+		v.controller.Stop()
 	}
 }
 
-func (l *vali) getClient(dynamicHosName string) client.ValiClient {
-	if l.isDynamicHost(dynamicHosName) && l.controller != nil {
-		if c, isStopped := l.controller.GetClient(dynamicHosName); !isStopped {
+func (v *vali) getClient(dynamicHosName string) client.ValiClient {
+	if v.isDynamicHost(dynamicHosName) && v.controller != nil {
+		if c, isStopped := v.controller.GetClient(dynamicHosName); !isStopped {
 			return c
 		}
 		return nil
 	}
 
-	return l.defaultClient
+	return v.defaultClient
 }
 
-func (l *vali) isDynamicHost(dynamicHostName string) bool {
+func (v *vali) isDynamicHost(dynamicHostName string) bool {
 	return dynamicHostName != "" &&
-		l.dynamicHostRegexp != nil &&
-		l.dynamicHostRegexp.MatchString(dynamicHostName)
+		v.dynamicHostRegexp != nil &&
+		v.dynamicHostRegexp.MatchString(dynamicHostName)
 }
 
-func (l *vali) setDynamicTenant(record map[string]interface{}, lbs model.LabelSet) model.LabelSet {
-	if l.dynamicTenantRegexp == nil {
+func (v *vali) setDynamicTenant(record map[string]interface{}, lbs model.LabelSet) model.LabelSet {
+	if v.dynamicTenantRegexp == nil {
 		return lbs
 	}
-	dynamicTenantFieldValue, ok := record[l.dynamicTenantField]
+	dynamicTenantFieldValue, ok := record[v.dynamicTenantField]
 	if !ok {
 		return lbs
 	}
 	s, ok := dynamicTenantFieldValue.(string)
-	if ok && l.dynamicTenantRegexp.MatchString(s) {
-		lbs[grafanavaliclient.ReservedLabelTenantID] = model.LabelValue(l.dynamicTenant)
+	if ok && v.dynamicTenantRegexp.MatchString(s) {
+		lbs[grafanavaliclient.ReservedLabelTenantID] = model.LabelValue(v.dynamicTenant)
 	}
 	return lbs
 }
 
-func (l *vali) send(client client.ValiClient, lbs model.LabelSet, ts time.Time, line string) error {
+func (v *vali) send(client client.ValiClient, lbs model.LabelSet, ts time.Time, line string) error {
 	return client.Handle(lbs, ts, line)
 }
 
-func (l *vali) addHostnameAsLabel(res model.LabelSet) error {
-	if l.cfg.PluginConfig.HostnameKey == nil {
+func (v *vali) addHostnameAsLabel(res model.LabelSet) error {
+	if v.cfg.PluginConfig.HostnameKey == nil {
 		return nil
 	}
-	if l.cfg.PluginConfig.HostnameValue != nil {
-		res[model.LabelName(*l.cfg.PluginConfig.HostnameKey)] = model.LabelValue(*l.cfg.PluginConfig.HostnameValue)
+	if v.cfg.PluginConfig.HostnameValue != nil {
+		res[model.LabelName(*v.cfg.PluginConfig.HostnameKey)] = model.LabelValue(*v.cfg.PluginConfig.HostnameValue)
 	} else {
 		hostname, err := os.Hostname()
 		if err != nil {
 			return err
 		}
-		res[model.LabelName(*l.cfg.PluginConfig.HostnameKey)] = model.LabelValue(hostname)
+		res[model.LabelName(*v.cfg.PluginConfig.HostnameKey)] = model.LabelValue(hostname)
 	}
 
 	return nil

--- a/pkg/valiplugin/vali.go
+++ b/pkg/valiplugin/vali.go
@@ -143,6 +143,7 @@ func (l *vali) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 
 	removeKeys(records, append(l.cfg.PluginConfig.LabelKeys, l.cfg.PluginConfig.RemoveKeys...))
 	if len(records) == 0 {
+		_ = level.Info(l.logger).Log("host", dynamicHostName, "issue", "no records left after removing keys")
 		metrics.DroppedLogs.WithLabelValues(host).Inc()
 		return nil
 	}
@@ -150,7 +151,7 @@ func (l *vali) SendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	client := l.getClient(dynamicHostName)
 
 	if client == nil {
-		_ = level.Debug(l.logger).Log("host", dynamicHostName, "issue", "could not find a client")
+		_ = level.Info(l.logger).Log("host", dynamicHostName, "issue", "could not find a client")
 		metrics.DroppedLogs.WithLabelValues(host).Inc()
 		return nil
 	}


### PR DESCRIPTION
The PR cleans up the code by removing old loki to vali migration code.
```other developer
None
```
