### PR TITLE
Upgrade golang dependencies

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -27,8 +27,8 @@ case "$(uname -m)" in
         ;;
 esac
 
-curl -LO "https://go.dev/dl/go1.22.4.linux-$ARCH.tar.gz"
-rm -rf /usr/local/go && tar -C /usr/local -xzf "go1.22.4.linux-$ARCH.tar.gz"
+curl -LO "https://go.dev/dl/go1.22.5.linux-$ARCH.tar.gz"
+rm -rf /usr/local/go && tar -C /usr/local -xzf "go1.22.5.linux-$ARCH.tar.gz"
 
 export \
   PATH="/usr/local/go/bin":$PATH \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.22.4 AS plugin-builder
+FROM golang:1.22.5 AS plugin-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -21,7 +21,7 @@ WORKDIR /
 CMD /bin/cp /source/plugins/. /plugins
 
 #############      image-builder       #############
-FROM golang:1.22.4 AS image-builder
+FROM golang:1.22.5 AS image-builder
 
 WORKDIR /go/src/github.com/gardener/logging
 COPY . .
@@ -51,7 +51,7 @@ WORKDIR /
 ENTRYPOINT [ "/event-logger" ]
 
 #############      telegraf-builder       #############
-FROM golang:1.22.4 AS telegraf-builder
+FROM golang:1.22.5 AS telegraf-builder
 RUN git clone --depth 1 --branch v1.26.0 https://github.com/influxdata/telegraf.git
 WORKDIR /go/telegraf
 ENV GOCACHE=/root/.cache/go-build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/logging
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/cortexproject/cortex v1.10.0


### PR DESCRIPTION
/kind enhancement
/area logging

This PR upgrades golang dependencies to 1.22.5 providing following important fix:
Validates fix for https://github.com/golang/go/issues/62440

```other developer
Bumps up golang version to 1.22.5.
```
