### PR TITLE
Add support for proxy configuraton

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It also adds additional configurations that aim to improve plugin's performance 
 | Key           | Description                                   | Default                             |
 | --------------|-----------------------------------------------|-------------------------------------|
 | Url           | Url of vali server API endpoint.               | `http://localhost:3100/vali/api/v1/push` |
+| ProxyURL      | Optional Url for http proxy.                   | ""                                 |
 | BatchWait     | Time to wait before send a log batch to Vali, full or not. (unit: sec) | 1 second   |
 | BatchSize     | Log batch size to send a log batch to Vali (unit: Bytes).    | 10 KiB (10 * 1024 Bytes) |
 | MaxRetries     | Number of times the vali client will try to send unsuccessful sent record to vali.    | 10 |

--- a/pkg/config/client_config.go
+++ b/pkg/config/client_config.go
@@ -10,6 +10,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	stdurl "net/url"
 	"strconv"
 	"time"
 
@@ -81,6 +82,16 @@ func initClientConfig(cfg Getter, res *Config) error {
 		return errors.New("failed to parse client URL")
 	}
 	res.ClientConfig.CredativValiConfig.URL = clientURL
+
+	proxyURL := cfg.Get("ProxyURL")
+	if proxyURL != "" {
+		u, err := stdurl.Parse(proxyURL)
+		if err != nil {
+			return fmt.Errorf("failed to parse proxy URL: %v", err)
+		}
+
+		res.ClientConfig.CredativValiConfig.Client.ProxyURL.URL = u
+	}
 
 	// cfg.Get will return empty string if not set, which is handled by the client library as no tenant
 	res.ClientConfig.CredativValiConfig.TenantID = cfg.Get("TenantID")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/credativ/vali/pkg/valitail/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/logging"
 	"k8s.io/utils/pointer"
@@ -181,6 +182,7 @@ var _ = Describe("Config", func() {
 		Entry("setting values", testArgs{
 			map[string]string{
 				"URL":             "http://somewhere.com:3100/vali/api/v1/push",
+				"ProxyURL":        "http://somewhere-proxy.com:1234",
 				"TenantID":        "my-tenant-id",
 				"LineFormat":      "key_value",
 				"LogLevel":        "warn",
@@ -217,6 +219,9 @@ var _ = Describe("Config", func() {
 						ExternalLabels: valiflag.LabelSet{LabelSet: model.LabelSet{"app": "foo"}},
 						BackoffConfig:  defaultBackoffConfig,
 						Timeout:        defaultTimeout,
+						Client: config.HTTPClientConfig{
+							ProxyURL: config.URL{URL: parseURL("http://somewhere-proxy.com:1234").URL},
+						},
 					},
 					BufferConfig: BufferConfig{
 						Buffer:     defaultBuffer,
@@ -668,6 +673,7 @@ var _ = Describe("Config", func() {
 			expectNoError},
 		),
 		Entry("bad url", testArgs{map[string]string{"URL": "::doh.com"}, nil, true}),
+		Entry("bad proxy url", testArgs{map[string]string{"ProxyURL": "::doh.com"}, nil, true}),
 		Entry("bad BatchWait", testArgs{map[string]string{"BatchWait": "a"}, nil, true}),
 		Entry("bad BatchSize", testArgs{map[string]string{"BatchSize": "a"}, nil, true}),
 		Entry("bad labels", testArgs{map[string]string{"Labels": "a"}, nil, true}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:

Previously, the proxy used by the internal http.Client was always empty, which means using direct connections to the target. For environments with limited internet access, this prevents loki log submission when using log destinations outside the cluster.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
An HTTP proxy can now be configured using the `ProxyURL` setting.
```