### PR TITLE
chore: bump up golangcli-lint to 1.62.0

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -4,7 +4,7 @@
 
 # linter dependency
 GO_LINT                                    := $(TOOLS_DIR)/golangci-lint
-GO_LINT_VERSION                            ?= v1.60.3
+GO_LINT_VERSION                            ?= v1.62.0
 # test dependencies
 GINKGO                                     := $(TOOLS_DIR)/ginkgo
 GINKGO_VERSION                             ?= $(call version_gomod,github.com/onsi/ginkgo/v2)


### PR DESCRIPTION
/kind testing
/area logging

This PR brings the latest golangcli-lint version.
- [release notes 1.62.0](https://github.com/golangci/golangci-lint/releases/tag/v1.62.0)

```other operator
NONE
```
