### PR TITLE
build: bump up vali to the latest released version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.5
 
 require (
 	github.com/cortexproject/cortex v1.10.0
-	github.com/credativ/vali v0.0.0-20240809071551-5cab200ebcfc
+	github.com/credativ/vali v0.0.0-20241206084847-26ee17826034
 	github.com/fluent/fluent-bit-go v0.0.0-20230731091245-a7a013e2473c
 	github.com/gardener/gardener v1.110.4
 	github.com/go-kit/log v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/credativ/vali v0.0.0-20240809071551-5cab200ebcfc h1:o1UdnosSmIhIT/rHhsFQ8T+Xm1GyV7dbJsk4njt8lL0=
-github.com/credativ/vali v0.0.0-20240809071551-5cab200ebcfc/go.mod h1:N2kBFZ91qaBBif79xrLtVNCUzMzqH5BEl+kLuaLU9AA=
+github.com/credativ/vali v0.0.0-20241206084847-26ee17826034 h1:JuSfKM74jfAIiO+1TBeUbc0tpucUDI2CqPqjK0Oy6eM=
+github.com/credativ/vali v0.0.0-20241206084847-26ee17826034/go.mod h1:N2kBFZ91qaBBif79xrLtVNCUzMzqH5BEl+kLuaLU9AA=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cyphar/filepath-securejoin v0.3.4 h1:VBWugsJh2ZxJmLFSM06/0qzQyiQX2Qs0ViKrUAcqdZ8=
 github.com/cyphar/filepath-securejoin v0.3.4/go.mod h1:8s/MCNJREmFK0H02MF6Ihv1nakJe4L/w3WZLHNkvlYM=


### PR DESCRIPTION
/kind enhancement
/area logging

This PR bumps up vali module dependency to the latest released version v0.0.0-20241206084847-26ee17826034
```other developer
None
```
