### PR TITLE
fix: add libeconf libs for tune2fs container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,7 @@ RUN mkdir -p ./lib ./usr/bin/ ./bin ./etc/bash ./usr/lib/bash ./usr/sbin/ ./etc/
     && cp -d /usr/lib/libcom_err.so.* ./lib                                 && echo "package e2fsprogs-extra" \
     && cp -d /usr/lib/libuuid.so.* ./lib                                    && echo "package e2fsprogs-extra" \
     && cp -d /usr/lib/libe2p.so.* ./lib                                     && echo "package e2fsprogs-extra" \
+    && cp -d /usr/lib/libeconf.so.* ./lib                                   && echo "package libeconf" \
     && cp -d /usr/sbin/tune2fs ./usr/sbin                                   && echo "package e2fsprogs-extra"
 
 #############      tune2fs       #############


### PR DESCRIPTION
**How to categorize this PR?**
/area logging

**What this PR does / why we need it**:
Add _libeconf_ libs to the _tune2fs_ container image as they are missing.
Using _europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs:v0.63.0_ as the container image for the _init-large-dir_ init container is going to fail with:
```
2025-01-31T07:37:18.990480524Z stderr F Error loading shared library libeconf.so.0: No such file or directory (needed by /lib/libblkid.so.1)
2025-01-31T07:37:18.990593708Z stderr F Error relocating /lib/libblkid.so.1: econf_getStringValue: symbol not found
2025-01-31T07:37:18.990602645Z stderr F Error relocating /lib/libblkid.so.1: econf_getBoolValue: symbol not found
2025-01-31T07:37:18.990607833Z stderr F Error relocating /lib/libblkid.so.1: econf_readFile: symbol not found
2025-01-31T07:37:18.990609399Z stderr F Error relocating /lib/libblkid.so.1: econf_freeFile: symbol not found
2025-01-31T07:37:18.990610815Z stderr F Error relocating /lib/libblkid.so.1: econf_readDirs: symbol not found
2025-01-31T07:37:18.990618544Z stderr F Error relocating /lib/libblkid.so.1: econf_errString: symbol not found
2025-01-31T07:37:18.991966686Z stderr F Error loading shared library libeconf.so.0: No such file or directory (needed by /lib/libblkid.so.1)
2025-01-31T07:37:18.992096714Z stderr F Error relocating /lib/libblkid.so.1: econf_getStringValue: symbol not found
2025-01-31T07:37:18.992100389Z stderr F Error relocating /lib/libblkid.so.1: econf_getBoolValue: symbol not found
2025-01-31T07:37:18.99210244Z stderr F Error relocating /lib/libblkid.so.1: econf_readFile: symbol not found
2025-01-31T07:37:18.992116965Z stderr F Error relocating /lib/libblkid.so.1: econf_freeFile: symbol not found
2025-01-31T07:37:18.992127837Z stderr F Error relocating /lib/libblkid.so.1: econf_readDirs: symbol not found
2025-01-31T07:37:18.992130768Z stderr F Error relocating /lib/libblkid.so.1: econf_errString: symbol not found
2025-01-31T07:37:18.992432515Z stdout F tune2fs -O large_dir $(mount | gawk '{if($3=="/data") {print $1}}') failed, exit code 127
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE

**Release note**:
NONE
