### PR TITLE
Update pipeline_definitions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,7 +9,7 @@ logging:
             We use gosec for sast scanning, see attached log.
     steps:
       verify:
-        image: 'golang:1.23.5'
+        image: 'golang:1.23.6'
     traits:
       version:
         preprocess:


### PR DESCRIPTION
/kind enhancement
/area logging

This PR bumps up the test image version to go1.23.6 in ci pipeline definition.

```other operator
None
```
