### PR TITLE
Update go to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/logging
 
-go 1.24.1
+go 1.24.2
 
 tool (
 	github.com/golangci/golangci-lint/cmd/golangci-lint
@@ -37,7 +37,6 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/e2e-framework v0.6.0
-
 )
 
 require (


### PR DESCRIPTION
/kind enhancement
/area logging

This PR brings go 1.24.2 to project module.

```other operator
None
```
