### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,10 @@ updates:
       interval: weekly
     commit-message:
       prefix: ":seedling:"
+  # Create PRs for GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ":seedling:"


### PR DESCRIPTION
This PR adds github actions updates to dependabot configuration.

```other developer
None
```
