### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,9 +38,9 @@ updates:
       prefix: ":seedling:"
     ignore:
       # Skip fluent-bit image updates. These shall be updated manually and in sync with the fluent-bit version in the Gardener project.
-      - dependency-name: ghcr.io/fluent/fluent-operator/fluent-bit-*
+      - dependency-name: ghcr.io/fluent/fluent-operator/fluent-bit
         versions:
-          - "*"
+          - ">= 3"
   # Create PRs for GitHub Actions updates
   - package-ecosystem: "github-actions"
     directory: /


### PR DESCRIPTION
This PR fixes docker ignore condition in dependabot configuration.

```other operator
None
```
