### PR TITLE
Apply auto inesrt summary only when the pr description is empty

### DIFF
--- a/.hyperspace/pull_request_bot.json
+++ b/.hyperspace/pull_request_bot.json
@@ -10,7 +10,7 @@
       "use_tabular_summarize_output_template": false
     },
     "review": {
-      "auto_generate_review": true,
+      "auto_generate_review": false,
       "use_custom_review_focus": false
     }
   }

--- a/.hyperspace/pull_request_bot_summarize_output_template.md
+++ b/.hyperspace/pull_request_bot_summarize_output_template.md
@@ -12,7 +12,7 @@
 {{ additional_context }}
 
 **Which issue(s) this PR fixes**:
-Fixes #
+Fixes #{{issue_number}}
 
 **Special notes for your reviewer**:
 

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -1,5 +1,7 @@
 # PR Summarization Prompt
 
+"auto_insert_summary" only applies when the PR description is empty.
+
 Summarize the changes in this pull request for a technical audience.
 Highlight the main features and improvements in one paragraph - required.
 Add bug fixes if any in the second paragraph - optional.


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/area logging

Auto insert summary on empty description.

```other developer
None
```
