### PR TITLE
Logs serialized as a map should be output in JSON format rather than logfmt

### DIFF
--- a/pkg/client/otlp_log_record_builder.go
+++ b/pkg/client/otlp_log_record_builder.go
@@ -4,9 +4,8 @@
 package client
 
 import (
-	"bytes"
+	"encoding/json"
 	"fmt"
-	"slices"
 	"time"
 
 	otlplog "go.opentelemetry.io/otel/log"
@@ -89,7 +88,10 @@ func extractBody(record map[string]any) string {
 		case map[string]any:
 			// For nested maps, avoid deep serialization that causes memory leaks
 			// Serialize the line and fetch 1024 bytes only
-			t := marshalMap(msg.(map[string]any))
+			t, err := marshalMap(msg.(map[string]any))
+			if err != nil {
+				return fmt.Sprintf("failed to marshal record: %s", err.Error())
+			}
 			if len(t) > 1024 {
 				return fmt.Sprintf("%s... <truncated %d bytes>", t[:1024], len(t)-1024)
 			}
@@ -113,7 +115,10 @@ func extractBody(record map[string]any) string {
 		case map[string]any:
 			// For nested maps, avoid deep serialization that causes memory leaks
 			// Serialize the line and fetch 1024 bytes only
-			t := marshalMap(msg.(map[string]any))
+			t, err := marshalMap(msg.(map[string]any))
+			if err != nil {
+				return fmt.Sprintf("failed to marshal record: %s", err.Error())
+			}
 			if len(t) > 1024 {
 				return fmt.Sprintf("%s... <truncated %d bytes>", t[:1024], len(t)-1024)
 			}
@@ -238,20 +243,11 @@ func convertToKeyValue(key string, value any) otlplog.KeyValue {
 	}
 }
 
-func marshalMap(m map[string]any) string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-
-	var b bytes.Buffer
-	for i, k := range keys {
-		if i > 0 {
-			_, _ = b.WriteString(" ")
-		}
-		_, _ = fmt.Fprintf(&b, "%s:%v", k, m[k])
+func marshalMap(m map[string]any) (string, error) {
+	jsonStr, err := json.Marshal(m)
+	if err != nil {
+		return "", err
 	}
 
-	return b.String()
+	return string(jsonStr), nil
 }

--- a/pkg/client/otlp_log_record_builder_test.go
+++ b/pkg/client/otlp_log_record_builder_test.go
@@ -4,6 +4,8 @@
 package client
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -215,6 +217,86 @@ var _ = Describe("LogRecordBuilder", func() {
 			Expect(body).To(ContainSubstring("field1"))
 			Expect(body).To(ContainSubstring("field2"))
 		})
+
+		It("should serialize map in 'log' field as JSON", func() {
+			record := map[string]any{
+				"log": map[string]any{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			}
+
+			body := extractBody(record)
+
+			Expect(body).To(ContainSubstring(`"key1":"value1"`))
+			Expect(body).To(ContainSubstring(`"key2":"value2"`))
+		})
+
+		It("should truncate large map in 'log' field", func() {
+			largeMap := make(map[string]any)
+			for i := range 200 {
+				largeMap[fmt.Sprintf("key_%04d", i)] = strings.Repeat("x", 10)
+			}
+			record := map[string]any{
+				"log": largeMap,
+			}
+
+			body := extractBody(record)
+
+			Expect(body).To(ContainSubstring("<truncated"))
+			Expect(len(body)).To(BeNumerically(">", 1024))
+		})
+
+		It("should serialize map in 'message' field as JSON", func() {
+			record := map[string]any{
+				"message": map[string]any{
+					"event": "started",
+					"pid":   float64(1234),
+				},
+			}
+
+			body := extractBody(record)
+
+			Expect(body).To(ContainSubstring(`"event":"started"`))
+			Expect(body).To(ContainSubstring(`"pid":1234`))
+		})
+
+		It("should truncate large map in 'message' field", func() {
+			largeMap := make(map[string]any)
+			for i := range 200 {
+				largeMap[fmt.Sprintf("key_%04d", i)] = strings.Repeat("x", 10)
+			}
+			record := map[string]any{
+				"message": largeMap,
+			}
+
+			body := extractBody(record)
+
+			Expect(body).To(ContainSubstring("<truncated"))
+			Expect(len(body)).To(BeNumerically(">", 1024))
+		})
+
+		It("should truncate large byte slice in 'log' field", func() {
+			record := map[string]any{
+				"log": []byte(strings.Repeat("a", 2048)),
+			}
+
+			body := extractBody(record)
+
+			Expect(body).To(ContainSubstring("<truncated"))
+			Expect(body).To(ContainSubstring("1024 bytes"))
+		})
+
+		It("should truncate large byte slice in 'message' field", func() {
+			record := map[string]any{
+				"message": []byte(strings.Repeat("b", 2048)),
+			}
+
+			body := extractBody(record)
+
+			Expect(body).To(ContainSubstring("<truncated"))
+			Expect(body).To(ContainSubstring("1024 bytes"))
+		})
 	})
 
 	Describe("convertToKeyValue", func() {
@@ -318,6 +400,56 @@ var _ = Describe("LogRecordBuilder", func() {
 			Expect(attrKeys).NotTo(ContainElement("log"))
 			Expect(attrKeys).NotTo(ContainElement("message"))
 			Expect(attrKeys).To(ContainElement("custom"))
+		})
+	})
+
+	Describe("marshalMap", func() {
+		It("should marshal a simple map to JSON", func() {
+			m := map[string]any{
+				"key": "value",
+			}
+
+			result, err := marshalMap(m)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(`{"key":"value"}`))
+		})
+
+		It("should marshal a map with multiple types", func() {
+			m := map[string]any{
+				"str":  "hello",
+				"num":  float64(42),
+				"bool": true,
+			}
+
+			result, err := marshalMap(m)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring(`"str":"hello"`))
+			Expect(result).To(ContainSubstring(`"num":42`))
+			Expect(result).To(ContainSubstring(`"bool":true`))
+		})
+
+		It("should marshal nested maps", func() {
+			m := map[string]any{
+				"outer": map[string]any{
+					"inner": "value",
+				},
+			}
+
+			result, err := marshalMap(m)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(`{"outer":{"inner":"value"}}`))
+		})
+
+		It("should marshal an empty map", func() {
+			m := map[string]any{}
+
+			result, err := marshalMap(m)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(`{}`))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/kind bug
/area logging

**What this PR does / why we need it**:
Restore the previous behaviour prior v0.71.0 records to be in json format, not logfmt.

**Which issue(s) this PR fixes**:
Continuation of https://github.com/gardener/gardener/pull/14423

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Logs serialized as a map will be output in JSON format rather than logfmt.
```
