### PR TITLE
Add OTLP metrics to the custom Prometheus registry

### DIFF
--- a/cmd/fluent-bit-output-plugin/output_plugin.go
+++ b/cmd/fluent-bit-output-plugin/output_plugin.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/component-base/version"
 
+	"github.com/gardener/logging/v1/pkg/client"
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/healthz"
 	"github.com/gardener/logging/v1/pkg/log"
@@ -40,6 +41,7 @@ var (
 	metricsInst     *metrics.FluentBitGardenerMetrics
 )
 
+// TODO(iypetrov): Refactor later to avoid global state + mixed responability of the components
 func init() {
 	logger = log.NewLogger("info")
 	logger.Info("Starting fluent-bit-gardener-output-plugin",
@@ -52,6 +54,9 @@ func init() {
 	// metrics and healthz
 	reg = metrics.NewRegistry()
 	metricsInst = metrics.NewFluentBitGardenerMetrics(reg)
+	globalMetricsSetup, metricsSetupErr := client.InitializeMetricsSetup(reg)
+	client.SetGlobalMetricsSetup(globalMetricsSetup)
+	client.SetGlobalMetricsSetupErr(metricsSetupErr)
 	go func() {
 		http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 		http.Handle("/healthz", healthz.Handler("", ""))

--- a/cmd/fluent-bit-output-plugin/output_plugin.go
+++ b/cmd/fluent-bit-output-plugin/output_plugin.go
@@ -54,9 +54,8 @@ func init() {
 	// metrics and healthz
 	reg = metrics.NewRegistry()
 	metricsInst = metrics.NewFluentBitGardenerMetrics(reg)
-	globalMetricsSetup, metricsSetupErr := client.InitializeMetricsSetup(reg)
+	globalMetricsSetup, _ := client.InitializeMetricsSetup(reg)
 	client.SetGlobalMetricsSetup(globalMetricsSetup)
-	client.SetGlobalMetricsSetupErr(metricsSetupErr)
 	go func() {
 		http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 		http.Handle("/healthz", healthz.Handler("", ""))

--- a/pkg/client/otlp_metrics_setup.go
+++ b/pkg/client/otlp_metrics_setup.go
@@ -9,7 +9,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"sync"
 
@@ -39,26 +38,28 @@ var (
 	metricsSetupErr error
 )
 
-func init() {
+func SetGlobalMetricsSetup(ms *MetricsSetup) {
+	globalMetricsSetup = ms
+}
+
+func SetGlobalMetricsSetupErr(err error) {
+	metricsSetupErr = err
+}
+
+// InitializeMetricsSetup creates and configures the metrics infrastructure.
+// This function is called exactly once by the singleton pattern.
+func InitializeMetricsSetup(reg *promclient.Registry) (*MetricsSetup, error) {
 	// Enable OpenTelemetry SDK observability (self-instrumentation) metrics.
 	// This is an experimental feature that emits metrics like otel.sdk.log.created,
 	// otel.sdk.exporter.* etc. The environment variable must be set before SDK initialization.
 	// See: https://pkg.go.dev/go.opentelemetry.io/otel/sdk/log/internal/x
 	_ = os.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
 
-	if globalMetricsSetup, metricsSetupErr = initializeMetricsSetup(); metricsSetupErr != nil {
-		slog.Error("Failed to initialize OTLP metrics setup", "error", metricsSetupErr)
-	}
-}
-
-// initializeMetricsSetup creates and configures the metrics infrastructure.
-// This function is called exactly once by the singleton pattern.
-func initializeMetricsSetup() (*MetricsSetup, error) {
 	// Create Prometheus exporter using the default registry
 	// This ensures OTLP metrics are exposed on the same /metrics endpoint
 	// as the existing Prometheus metrics (port 2021)
 	promExporter, err := prometheus.New(
-		prometheus.WithRegisterer(promclient.DefaultRegisterer),
+		prometheus.WithRegisterer(reg),
 		prometheus.WithNamespace("output_plugin"),
 		prometheus.WithTranslationStrategy(otlptranslator.UnderscoreEscapingWithSuffixes),
 	)

--- a/pkg/client/otlp_metrics_setup.go
+++ b/pkg/client/otlp_metrics_setup.go
@@ -33,17 +33,11 @@ var (
 	// globalMetricsSetup is the singleton instance shared across all OTLP clients.
 	// It is initialized during package initialization and reused for all subsequent requests.
 	globalMetricsSetup *MetricsSetup
-
-	// metricsSetupErr stores any initialization error that occurred during setup.
-	metricsSetupErr error
 )
 
+// SetGlobalMetricsSetup sets the value to the glbal OTLP metrics setup.
 func SetGlobalMetricsSetup(ms *MetricsSetup) {
 	globalMetricsSetup = ms
-}
-
-func SetGlobalMetricsSetupErr(err error) {
-	metricsSetupErr = err
 }
 
 // InitializeMetricsSetup creates and configures the metrics infrastructure.

--- a/pkg/client/otlp_metrics_setup_test.go
+++ b/pkg/client/otlp_metrics_setup_test.go
@@ -8,44 +8,49 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	promclient "github.com/prometheus/client_golang/prometheus"
 )
 
 var _ = Describe("MetricsSetup Singleton", func() {
-	It("should be initialized during package init", func() {
-		Expect(metricsSetupErr).ToNot(HaveOccurred())
-		Expect(globalMetricsSetup).ToNot(BeNil())
+	var metricsSetup *MetricsSetup
+
+	BeforeEach(func() {
+		reg := promclient.NewRegistry()
+		var err error
+		metricsSetup, err = InitializeMetricsSetup(reg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metricsSetup).ToNot(BeNil())
+	})
+
+	It("should be initialized successfully", func() {
+		Expect(metricsSetup).ToNot(BeNil())
 	})
 
 	It("should return the same meter provider instance", func() {
-		provider1 := globalMetricsSetup.GetProvider()
-		provider2 := globalMetricsSetup.GetProvider()
+		provider1 := metricsSetup.GetProvider()
+		provider2 := metricsSetup.GetProvider()
 
 		// Should be the exact same provider instance
 		Expect(provider1).To(BeIdenticalTo(provider2))
 	})
 
 	It("should shutdown idempotently - multiple shutdowns should not error", func() {
-		Expect(metricsSetupErr).ToNot(HaveOccurred())
-		Expect(globalMetricsSetup).ToNot(BeNil())
-
 		ctx := context.Background()
 
 		// First shutdown
-		err := globalMetricsSetup.Shutdown(ctx)
+		err := metricsSetup.Shutdown(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Second shutdown should not error (idempotent)
-		err = globalMetricsSetup.Shutdown(ctx)
+		err = metricsSetup.Shutdown(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Third shutdown should also not error
-		err = globalMetricsSetup.Shutdown(ctx)
+		err = metricsSetup.Shutdown(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should handle concurrent shutdown calls", func() {
-		Expect(metricsSetupErr).ToNot(HaveOccurred())
-
 		const goroutines = 10
 		errors := make([]error, goroutines)
 		done := make(chan bool)
@@ -55,7 +60,7 @@ var _ = Describe("MetricsSetup Singleton", func() {
 		// Multiple goroutines try to shutdown simultaneously
 		for i := range goroutines {
 			go func(index int) {
-				errors[index] = globalMetricsSetup.Shutdown(ctx)
+				errors[index] = metricsSetup.Shutdown(ctx)
 				done <- true
 			}(i)
 		}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/area logging

**What this PR does / why we need it**:
#495 caused OTLP metrics to be registered with the default Prometheus registry instead of the custom registry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
OTLP metrics were accidentally removed in #495, get them back.
```
