### PR TITLE
Refactored the NOOP client into a separate package

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,9 +17,6 @@ import (
 	"github.com/gardener/logging/v1/pkg/types"
 )
 
-// NewFunc is a function type for creating new api.Output instances
-type NewFunc func(ctx context.Context, cfg config.Config, logger logr.Logger, m *metrics.FluentBitGardenerMetrics) (api.Output, error)
-
 type clientOptions struct {
 	target  targets.Target
 	logger  logr.Logger
@@ -71,38 +68,25 @@ func NewClient(ctx context.Context, cfg config.Config, opts ...Option) (api.Outp
 		logger = logr.Discard() // Default no-op logger
 	}
 
-	var nf NewFunc
-	var err error
+	var t types.Type
 	switch options.target {
 	case targets.Seed:
-		t := types.GetClientTypeFromString(cfg.PluginConfig.SeedType)
-		nf, err = getNewFunc(t)
-		if err != nil {
-			return nil, err
-		}
+		t = types.GetClientTypeFromString(cfg.PluginConfig.SeedType)
 	case targets.Shoot:
-		t := types.GetClientTypeFromString(cfg.PluginConfig.ShootType)
-		nf, err = getNewFunc(t)
-		if err != nil {
-			return nil, err
-		}
+		t = types.GetClientTypeFromString(cfg.PluginConfig.ShootType)
 	default:
 		return nil, fmt.Errorf("unknown target type: %v", options.target)
 	}
 
-	return nf(ctx, cfg, logger, options.metrics)
-}
-
-func getNewFunc(t types.Type) (NewFunc, error) {
 	switch t {
 	case types.OTLPGRPC:
-		return NewOTLPGRPCClient, nil
+		return NewOTLPGRPCClient(ctx, cfg, logger, options.metrics)
 	case types.OTLPHTTP:
-		return NewOTLPHTTPClient, nil
+		return NewOTLPHTTPClient(ctx, cfg, logger, options.metrics)
 	case types.STDOUT:
-		return NewStdoutClient, nil
+		return NewStdoutClient(ctx, cfg, logger, options.metrics)
 	case types.NOOP:
-		return noopclient.New, nil
+		return noopclient.New(ctx, cfg, logger, options.metrics)
 	default:
 		return nil, fmt.Errorf("unknown client type: %v", t)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/gardener/logging/v1/pkg/client/api"
+	noopclient "github.com/gardener/logging/v1/pkg/client/noop"
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/metrics"
 	"github.com/gardener/logging/v1/pkg/targets"
@@ -101,7 +102,7 @@ func getNewFunc(t types.Type) (NewFunc, error) {
 	case types.STDOUT:
 		return NewStdoutClient, nil
 	case types.NOOP:
-		return NewNoopClient, nil
+		return noopclient.New, nil
 	default:
 		return nil, fmt.Errorf("unknown client type: %v", t)
 	}

--- a/pkg/client/noop/noop_client.go
+++ b/pkg/client/noop/noop_client.go
@@ -30,7 +30,7 @@ type Client struct {
 var _ api.Output = &Client{}
 
 // New creates a new NoopClient that discards all records
-func New(ctx context.Context, cfg config.Config, logger logr.Logger, m *metrics.FluentBitGardenerMetrics) (api.Output, error) {
+func New(ctx context.Context, cfg config.Config, logger logr.Logger, m *metrics.FluentBitGardenerMetrics) (*Client, error) {
 	client := &Client{
 		ctx:      ctx,
 		endpoint: cfg.OTLPConfig.Endpoint,

--- a/pkg/client/noop/noop_client.go
+++ b/pkg/client/noop/noop_client.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package client
+package noop
 
 import (
 	"context"
@@ -18,20 +18,20 @@ import (
 
 const componentNoopName = "noop"
 
-// NoopClient is an implementation of Output that discards all records
+// Client is an implementation of Output that discards all records
 // but keeps metrics and increments counters
-type NoopClient struct {
+type Client struct {
 	ctx      context.Context
 	logger   logr.Logger
 	endpoint string
 	metrics  *metrics.FluentBitGardenerMetrics
 }
 
-var _ api.Output = &NoopClient{}
+var _ api.Output = &Client{}
 
-// NewNoopClient creates a new NoopClient that discards all records
-func NewNoopClient(ctx context.Context, cfg config.Config, logger logr.Logger, m *metrics.FluentBitGardenerMetrics) (api.Output, error) {
-	client := &NoopClient{
+// New creates a new NoopClient that discards all records
+func New(ctx context.Context, cfg config.Config, logger logr.Logger, m *metrics.FluentBitGardenerMetrics) (api.Output, error) {
+	client := &Client{
 		ctx:      ctx,
 		endpoint: cfg.OTLPConfig.Endpoint,
 		logger:   logger.WithValues("endpoint", cfg.OTLPConfig.Endpoint),
@@ -44,7 +44,7 @@ func NewNoopClient(ctx context.Context, cfg config.Config, logger logr.Logger, m
 }
 
 // Handle processes and discards the log entry while incrementing metrics
-func (c *NoopClient) Handle(_ types.OutputEntry) error {
+func (c *Client) Handle(_ types.OutputEntry) error {
 	// Increment the dropped logs counter since we're discarding the record
 	c.metrics.DroppedLogs.WithLabelValues(c.endpoint, "noop").Inc()
 
@@ -53,16 +53,16 @@ func (c *NoopClient) Handle(_ types.OutputEntry) error {
 }
 
 // Stop shuts down the client immediately
-func (c *NoopClient) Stop() {
+func (c *Client) Stop() {
 	c.logger.V(2).Info(fmt.Sprintf("stopping %s", componentNoopName))
 }
 
 // StopWait stops the client - since this is a no-op client, it's the same as Stop
-func (c *NoopClient) StopWait() {
+func (c *Client) StopWait() {
 	c.logger.V(2).Info(fmt.Sprintf("stopping %s with wait", componentNoopName))
 }
 
 // GetEndpoint returns the configured endpoint
-func (c *NoopClient) GetEndpoint() string {
+func (c *Client) GetEndpoint() string {
 	return c.endpoint
 }

--- a/pkg/client/noop/noop_client_test.go
+++ b/pkg/client/noop/noop_client_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package client
+package noop
 
 import (
 	"context"
@@ -34,7 +34,7 @@ var _ = Describe("NoopClient", func() {
 		cfg = config.Config{}
 
 		logger = log.NewNopLogger()
-		outputClient, _ = NewNoopClient(
+		outputClient, _ = New(
 			context.Background(),
 			cfg,
 			logger,
@@ -51,14 +51,14 @@ var _ = Describe("NoopClient", func() {
 				},
 			}
 
-			testClient, err := NewNoopClient(context.Background(), testCfg, logger, testMetrics)
+			testClient, err := New(context.Background(), testCfg, logger, testMetrics)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testClient).NotTo(BeNil())
 			Expect(testClient.GetEndpoint()).To(Equal(testEndpoint))
 		})
 
 		It("should work with nil logger", func() {
-			testClient, err := NewNoopClient(context.Background(), cfg, logger, testMetrics)
+			testClient, err := New(context.Background(), cfg, logger, testMetrics)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testClient).NotTo(BeNil())
 		})
@@ -70,7 +70,7 @@ var _ = Describe("NoopClient", func() {
 				},
 			}
 
-			testClient, err := NewNoopClient(context.Background(), testCfg, logger, testMetrics)
+			testClient, err := New(context.Background(), testCfg, logger, testMetrics)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testClient).NotTo(BeNil())
 			Expect(testClient.GetEndpoint()).To(Equal(""))
@@ -180,7 +180,7 @@ var _ = Describe("NoopClient", func() {
 				},
 			}
 
-			testClient, err := NewNoopClient(context.Background(), testCfg, logger, testMetrics)
+			testClient, err := New(context.Background(), testCfg, logger, testMetrics)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testClient.GetEndpoint()).To(Equal(testEndpoint))
 		})
@@ -202,9 +202,9 @@ var _ = Describe("NoopClient", func() {
 				},
 			}
 
-			client1, err := NewNoopClient(context.Background(), cfg1, logger, testMetrics)
+			client1, err := New(context.Background(), cfg1, logger, testMetrics)
 			Expect(err).NotTo(HaveOccurred())
-			client2, err := NewNoopClient(context.Background(), cfg2, logger, testMetrics)
+			client2, err := New(context.Background(), cfg2, logger, testMetrics)
 			Expect(err).NotTo(HaveOccurred())
 
 			metric1 := testMetrics.DroppedLogs.WithLabelValues(endpoint1, "noop")

--- a/pkg/controller/client_test.go
+++ b/pkg/controller/client_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
-	"github.com/gardener/logging/v1/pkg/client"
 	"github.com/gardener/logging/v1/pkg/client/api"
+	noopclient "github.com/gardener/logging/v1/pkg/client/noop"
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/log"
 	"github.com/gardener/logging/v1/pkg/metrics"
@@ -43,7 +43,7 @@ var _ = Describe("Controller Client", func() {
 		testMetrics = metrics.NewFluentBitGardenerMetrics(reg)
 
 		// Create separate NoopClient instances with different endpoints for separate metrics
-		shootClient, err := client.NewNoopClient(
+		shootClient, err := noopclient.New(
 			context.Background(),
 			config.Config{
 				OTLPConfig: config.OTLPConfig{
@@ -52,7 +52,7 @@ var _ = Describe("Controller Client", func() {
 			}, logger, testMetrics)
 		Expect(err).ToNot(HaveOccurred())
 
-		seedClient, err := client.NewNoopClient(
+		seedClient, err := noopclient.New(
 			context.Background(),
 			config.Config{
 				OTLPConfig: config.OTLPConfig{
@@ -436,7 +436,7 @@ var _ = Describe("Controller Client", func() {
 		)
 
 		BeforeEach(func() {
-			noopClient, err := client.NewNoopClient(
+			noopClient, err := noopclient.New(
 				context.Background(),
 				config.Config{
 					OTLPConfig: config.OTLPConfig{

--- a/tests/plugin/simple_test.go
+++ b/tests/plugin/simple_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/gardener/logging/v1/pkg/client"
+	noopclient "github.com/gardener/logging/v1/pkg/client/noop"
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/log"
 	"github.com/gardener/logging/v1/pkg/metrics"
@@ -31,7 +31,7 @@ var _ = Describe("Simple Plugin Test", func() {
 			},
 		}
 
-		c, err := client.NewNoopClient(context.Background(), cfg, logger, testMetrics)
+		c, err := noopclient.New(context.Background(), cfg, logger, testMetrics)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c).NotTo(BeNil())
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/area logging

**What this PR does / why we need it**:
Refactored the NOOP client into a separate package + updated the New function to return a concrete struct instead of an interface, following the recommendation from `100 Go Mistakes (Chapter 7: “Returning interfaces”)`.
> If we apply this idiom to Go, it means
> - Returning structs instead of interfaces
> - Accepting interfaces if possible

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Refactored the NOOP client into a separate package.
```
