### PR TITLE
feat(fluent-bit-output-plugin): Add dynamic CRD detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.81.1
 	k8s.io/api v0.35.1
+	k8s.io/apiextensions-apiserver v0.35.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
 	k8s.io/component-base v0.35.1
@@ -124,7 +125,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/controller/awaitcontroller_test.go
+++ b/pkg/controller/awaitcontroller_test.go
@@ -30,8 +30,8 @@ type fakeController struct {
 	stopped int
 }
 
-func (f *fakeController) GetClient(_ string) (api.Output, bool) { return nil, false }
-func (f *fakeController) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
+func (*fakeController) GetClient(_ string) (api.Output, bool) { return nil, false }
+func (*fakeController) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 func (f *fakeController) Stop() { f.stopped++ }
@@ -42,22 +42,26 @@ func (f *fakeController) Stop() { f.stopped++ }
 func fakeDynamicScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+
 	return s
 }
 
-// crdUnstructured returns a CustomResourceDefinition as *unstructured.Unstructured
-// so the fake dynamic client can serve it. The CRD is built typed first to keep
-// the test readable, then converted.
-func crdUnstructured(name, group string, established bool) *unstructured.Unstructured {
-	conds := []apiextensionsv1.CustomResourceDefinitionCondition{}
-	status := apiextensionsv1.ConditionFalse
-	if established {
-		status = apiextensionsv1.ConditionTrue
+// establishedCRD returns a CRD whose Established/NamesAccepted conditions are
+// True. pendingCRD returns one whose conditions are False. Splitting these
+// keeps the call sites self-describing and avoids a control-flag parameter.
+func establishedCRD(name, group string) *unstructured.Unstructured {
+	return crdUnstructuredWithStatus(name, group, apiextensionsv1.ConditionTrue)
+}
+
+func pendingCRD(name, group string) *unstructured.Unstructured {
+	return crdUnstructuredWithStatus(name, group, apiextensionsv1.ConditionFalse)
+}
+
+func crdUnstructuredWithStatus(name, group string, status apiextensionsv1.ConditionStatus) *unstructured.Unstructured {
+	conds := []apiextensionsv1.CustomResourceDefinitionCondition{
+		{Type: apiextensionsv1.Established, Status: status},
+		{Type: apiextensionsv1.NamesAccepted, Status: status},
 	}
-	conds = append(conds,
-		apiextensionsv1.CustomResourceDefinitionCondition{Type: apiextensionsv1.Established, Status: status},
-		apiextensionsv1.CustomResourceDefinitionCondition{Type: apiextensionsv1.NamesAccepted, Status: status},
-	)
 
 	crd := &apiextensionsv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
@@ -70,6 +74,7 @@ func crdUnstructured(name, group string, established bool) *unstructured.Unstruc
 	}
 	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(crd)
 	Expect(err).NotTo(HaveOccurred())
+
 	return &unstructured.Unstructured{Object: out}
 }
 
@@ -90,7 +95,7 @@ var _ = Describe("awaitController", func() {
 	It("delivers the controller for Cluster once that CRD is Established", func() {
 		fc := &fakeController{}
 		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
-			crdUnstructured("clusters.extensions.gardener.cloud", "extensions.gardener.cloud", true))
+			establishedCRD("clusters.extensions.gardener.cloud", "extensions.gardener.cloud"))
 
 		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
 			func(_ context.Context) (Controller, error) { return fc, nil },
@@ -105,7 +110,7 @@ var _ = Describe("awaitController", func() {
 	It("delivers the controller for OpenTelemetryCollector once that CRD is Established", func() {
 		fc := &fakeController{}
 		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
-			crdUnstructured("opentelemetrycollectors.opentelemetry.io", "opentelemetry.io", true))
+			establishedCRD("opentelemetrycollectors.opentelemetry.io", "opentelemetry.io"))
 
 		out, err := awaitController(ctx, l, otelcolScheme, &otelcolv1beta1.OpenTelemetryCollector{}, dyn,
 			func(_ context.Context) (Controller, error) { return fc, nil },
@@ -117,12 +122,13 @@ var _ = Describe("awaitController", func() {
 
 	It("does not deliver while the CRD exists but is not yet Established", func() {
 		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
-			crdUnstructured("clusters.extensions.gardener.cloud", "extensions.gardener.cloud", false))
+			pendingCRD("clusters.extensions.gardener.cloud", "extensions.gardener.cloud"))
 
 		built := false
 		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
 			func(_ context.Context) (Controller, error) {
 				built = true
+
 				return &fakeController{}, nil
 			},
 		)
@@ -135,7 +141,7 @@ var _ = Describe("awaitController", func() {
 	It("ignores CRDs in a different group even if their name matches", func() {
 		// Same plural+name shape but a different group — must not match.
 		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
-			crdUnstructured("clusters.extensions.gardener.cloud", "wrong.group.example.com", true))
+			establishedCRD("clusters.extensions.gardener.cloud", "wrong.group.example.com"))
 
 		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
 			func(_ context.Context) (Controller, error) { return &fakeController{}, nil },
@@ -151,6 +157,7 @@ var _ = Describe("awaitController", func() {
 		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
 			func(_ context.Context) (Controller, error) {
 				Fail("build must not run when ctx is cancelled before the CRD is established")
+
 				return nil, nil
 			},
 		)
@@ -162,7 +169,7 @@ var _ = Describe("awaitController", func() {
 
 	It("closes the channel without a value when `build` returns an error", func() {
 		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
-			crdUnstructured("clusters.extensions.gardener.cloud", "extensions.gardener.cloud", true))
+			establishedCRD("clusters.extensions.gardener.cloud", "extensions.gardener.cloud"))
 
 		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
 			func(_ context.Context) (Controller, error) {

--- a/pkg/controller/awaitcontroller_test.go
+++ b/pkg/controller/awaitcontroller_test.go
@@ -1,0 +1,186 @@
+// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	otelcolv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/gardener/logging/v1/pkg/client/api"
+)
+
+// fakeController is the minimal Controller implementation `build` callbacks
+// can return; it tracks how many times Stop has been invoked so we can assert
+// that successful builds make it through to the channel.
+type fakeController struct {
+	stopped int
+}
+
+func (f *fakeController) GetClient(_ string) (api.Output, bool) { return nil, false }
+func (f *fakeController) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+func (f *fakeController) Stop() { f.stopped++ }
+
+// fakeDynamicScheme builds a runtime.Scheme that knows about
+// CustomResourceDefinition. NewSimpleDynamicClient needs the scheme to derive
+// the list-kind for the resources it serves.
+func fakeDynamicScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	return s
+}
+
+// crdUnstructured returns a CustomResourceDefinition as *unstructured.Unstructured
+// so the fake dynamic client can serve it. The CRD is built typed first to keep
+// the test readable, then converted.
+func crdUnstructured(name, group string, established bool) *unstructured.Unstructured {
+	conds := []apiextensionsv1.CustomResourceDefinitionCondition{}
+	status := apiextensionsv1.ConditionFalse
+	if established {
+		status = apiextensionsv1.ConditionTrue
+	}
+	conds = append(conds,
+		apiextensionsv1.CustomResourceDefinitionCondition{Type: apiextensionsv1.Established, Status: status},
+		apiextensionsv1.CustomResourceDefinitionCondition{Type: apiextensionsv1.NamesAccepted, Status: status},
+	)
+
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       apiextensionsv1.CustomResourceDefinitionSpec{Group: group},
+		Status:     apiextensionsv1.CustomResourceDefinitionStatus{Conditions: conds},
+	}
+	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(crd)
+	Expect(err).NotTo(HaveOccurred())
+	return &unstructured.Unstructured{Object: out}
+}
+
+var _ = Describe("awaitController", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		l      logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+		l = logr.Discard()
+	})
+
+	AfterEach(func() { cancel() })
+
+	It("delivers the controller for Cluster once that CRD is Established", func() {
+		fc := &fakeController{}
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
+			crdUnstructured("clusters.extensions.gardener.cloud", "extensions.gardener.cloud", true))
+
+		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
+			func(_ context.Context) (Controller, error) { return fc, nil },
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var got Controller
+		Eventually(out, "5s", "20ms").Should(Receive(&got))
+		Expect(got).To(BeIdenticalTo(Controller(fc)))
+	})
+
+	It("delivers the controller for OpenTelemetryCollector once that CRD is Established", func() {
+		fc := &fakeController{}
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
+			crdUnstructured("opentelemetrycollectors.opentelemetry.io", "opentelemetry.io", true))
+
+		out, err := awaitController(ctx, l, otelcolScheme, &otelcolv1beta1.OpenTelemetryCollector{}, dyn,
+			func(_ context.Context) (Controller, error) { return fc, nil },
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(out, "5s", "20ms").Should(Receive(BeIdenticalTo(Controller(fc))))
+	})
+
+	It("does not deliver while the CRD exists but is not yet Established", func() {
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
+			crdUnstructured("clusters.extensions.gardener.cloud", "extensions.gardener.cloud", false))
+
+		built := false
+		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
+			func(_ context.Context) (Controller, error) {
+				built = true
+				return &fakeController{}, nil
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(out, "300ms", "20ms").ShouldNot(Receive())
+		Expect(built).To(BeFalse())
+	})
+
+	It("ignores CRDs in a different group even if their name matches", func() {
+		// Same plural+name shape but a different group — must not match.
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
+			crdUnstructured("clusters.extensions.gardener.cloud", "wrong.group.example.com", true))
+
+		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
+			func(_ context.Context) (Controller, error) { return &fakeController{}, nil },
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(out, "300ms", "20ms").ShouldNot(Receive())
+	})
+
+	It("closes the channel without a value when ctx is cancelled before the CRD shows up", func() {
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme())
+
+		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
+			func(_ context.Context) (Controller, error) {
+				Fail("build must not run when ctx is cancelled before the CRD is established")
+				return nil, nil
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		cancel()
+		Eventually(out, "2s", "20ms").Should(BeClosed())
+	})
+
+	It("closes the channel without a value when `build` returns an error", func() {
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(),
+			crdUnstructured("clusters.extensions.gardener.cloud", "extensions.gardener.cloud", true))
+
+		out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dyn,
+			func(_ context.Context) (Controller, error) {
+				return nil, errors.New("boom")
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(out, "5s", "20ms").Should(BeClosed())
+	})
+
+	It("returns a synchronous error when the typed object is not registered in the scheme", func() {
+		// extensionsv1alpha1.Cluster against otelcolScheme — not registered there.
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme())
+
+		_, err := awaitController(ctx, l, otelcolScheme, &extensionsv1alpha1.Cluster{}, dyn,
+			func(_ context.Context) (Controller, error) { return &fakeController{}, nil },
+		)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/controller/awaitcontroller_test.go
+++ b/pkg/controller/awaitcontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2026 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,11 +28,6 @@ import (
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/metrics"
 	"github.com/gardener/logging/v1/pkg/targets"
-)
-
-const (
-	clusterCRDGroup = "extensions.gardener.cloud"
-	clusterCRDName  = "clusters.extensions.gardener.cloud"
 )
 
 var scheme = func() *runtime.Scheme {
@@ -66,65 +60,88 @@ type clusterReconciler struct {
 }
 
 // newClusterController creates a new Controller for Cluster resources.
-// It sets up a manager and reconciler for Cluster resources.
-func newClusterController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (<-chan Controller, error) {
-	ch := make(chan Controller, 1)
-
-	var err error
-	var seedClient api.Output
-
+//
+// The seed client is created synchronously, then awaitController is started:
+// it watches the apiextensions API and, once the Cluster CRD is Established,
+// builds the controller-runtime manager and reconciler and delivers the
+// resulting Controller on the returned channel.
+func newClusterController(
+	ctx context.Context,
+	conf *config.Config,
+	l logr.Logger,
+	m *metrics.FluentBitGardenerMetrics,
+	ms *otlp.MetricsSetup,
+) (<-chan Controller, error) {
 	cfgShallowCopy := *conf
-	cfgShallowCopy.OTLPConfig.DQueConfig.DQueName = conf.OTLPConfig.DQueConfig.DQueName + "-controller"
-	opt := []client.Option{client.WithTarget(targets.Seed), client.WithLogger(l), client.WithMetrics(m), client.WithOTLPMetricsSetup(ms)}
+	cfgShallowCopy.OTLPConfig.DQueConfig.DQueName = fmt.Sprintf(
+		"%s-controller",
+		conf.OTLPConfig.DQueConfig.DQueName,
+	)
 
-	if seedClient, err = client.NewClient(ctx, cfgShallowCopy, opt...); err != nil {
+	opt := []client.Option{
+		client.WithTarget(targets.Seed),
+		client.WithLogger(l),
+		client.WithMetrics(m),
+		client.WithOTLPMetricsSetup(ms),
+	}
+
+	seedClient, err := client.NewClient(ctx, cfgShallowCopy, opt...)
+	if err != nil {
 		return nil, fmt.Errorf("failed to create seed client in controller: %w", err)
 	}
 	m.Clients.WithLabelValues(targets.Seed.String()).Inc()
 
+	out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{},
+		func(ctx context.Context) (Controller, error) {
+			return buildClusterReconciler(ctx, conf, l, m, ms, seedClient)
+		},
+	)
+	if err != nil {
+		seedClient.StopWait()
+		return nil, fmt.Errorf("failed to await Cluster controller: %w", err)
+	}
+	return out, nil
+}
+
+// buildClusterReconciler constructs the controller-runtime manager and the
+// clusterReconciler. It is invoked by awaitController once the Cluster CRD
+// is observed on the cluster.
+func buildClusterReconciler(
+	ctx context.Context,
+	conf *config.Config,
+	l logr.Logger,
+	m *metrics.FluentBitGardenerMetrics,
+	ms *otlp.MetricsSetup,
+	seedClient api.Output,
+) (Controller, error) {
 	restConfig, err := getRestConfig()
 	if err != nil {
-		seedClient.StopWait()
-
 		return nil, fmt.Errorf("failed to get REST config: %w", err)
-	}
-
-	dynamicClient, err := dynamic.NewForConfig(restConfig)
-	if err != nil {
-		seedClient.StopWait()
-
-		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
-	}
-
-	if err := waitForCRD(ctx, l, dynamicClient, clusterCRDGroup, clusterCRDName); err != nil {
-		seedClient.StopWait()
-
-		return nil, fmt.Errorf("failed waiting for CRD %s: %w", clusterCRDName, err)
 	}
 
 	ctlCtx, cancel := context.WithCancel(ctx)
 
 	ctrl.SetLogger(l)
-
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Logger: l,
 		Cache: cache.Options{
-			// Restrict cache to Cluster objects only; this controller does not reconcile other types.
+			// Restrict cache to Cluster objects only.
+			// This controller doesn't reconcile other types.
 			ByObject: map[k8sclient.Object]cache.ByObject{
 				&extensionsv1alpha1.Cluster{}: {},
 			},
-			// Strip managed fields from all cached objects as they are not used by the reconciler.
+			// Strip managed fields from all cached objects
+			// as they are not used by the reconciler.
 			DefaultTransform: cache.TransformStripManagedFields(),
 		},
-		// Disable metrics and health probe servers since fluent-bit plugin handles these
+		// Disable metrics and health probe servers
+		// since fluent-bit plugin handles these.
 		Metrics:                ctrl.Options{}.Metrics,
 		HealthProbeBindAddress: "",
 	})
 	if err != nil {
 		cancel()
-		seedClient.StopWait()
-
 		return nil, fmt.Errorf("failed to create manager: %w", err)
 	}
 
@@ -142,13 +159,11 @@ func newClusterController(ctx context.Context, conf *config.Config, l logr.Logge
 		metricsSetup: ms,
 	}
 
-	if err = ctrl.NewControllerManagedBy(mgr).
+	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&extensionsv1alpha1.Cluster{}).
 		Named(fmt.Sprintf("cluster-%s", uuid.NewUUID())).
 		Complete(reconciler); err != nil {
 		cancel()
-		seedClient.StopWait()
-
 		return nil, fmt.Errorf("failed to create controller: %w", err)
 	}
 
@@ -167,16 +182,12 @@ func newClusterController(ctx context.Context, conf *config.Config, l logr.Logge
 
 	if !mgr.GetCache().WaitForCacheSync(syncCtx) {
 		cancel()
-		seedClient.StopWait()
-
 		return nil, errors.New("failed to wait for cache sync within timeout")
 	}
 
 	l.Info("controller started and cache synced")
 
-	ch <- reconciler
-
-	return ch, nil
+	return reconciler, nil
 }
 
 // NewControllerWithClient creates a Controller with a pre-configured client.

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -94,6 +94,7 @@ func newClusterController(
 	dynamicClient, err := newDynamicClient()
 	if err != nil {
 		seedClient.StopWait()
+
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
@@ -104,8 +105,10 @@ func newClusterController(
 	)
 	if err != nil {
 		seedClient.StopWait()
+
 		return nil, fmt.Errorf("failed to await Cluster controller: %w", err)
 	}
+
 	return out, nil
 }
 

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -61,7 +61,9 @@ type clusterReconciler struct {
 
 // newClusterController creates a new Controller for Cluster resources.
 // It sets up a manager and reconciler for Cluster resources.
-func newClusterController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (Controller, error) {
+func newClusterController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (<-chan Controller, error) {
+	ch := make(chan Controller, 1)
+
 	var err error
 	var seedClient api.Output
 
@@ -153,7 +155,9 @@ func newClusterController(ctx context.Context, conf *config.Config, l logr.Logge
 
 	l.Info("controller started and cache synced")
 
-	return reconciler, nil
+	ch <- reconciler
+
+	return ch, nil
 }
 
 // NewControllerWithClient creates a Controller with a pre-configured client.

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -91,7 +91,13 @@ func newClusterController(
 	}
 	m.Clients.WithLabelValues(targets.Seed.String()).Inc()
 
-	out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{},
+	dynamicClient, err := newDynamicClient()
+	if err != nil {
+		seedClient.StopWait()
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	out, err := awaitController(ctx, l, scheme, &extensionsv1alpha1.Cluster{}, dynamicClient,
 		func(ctx context.Context) (Controller, error) {
 			return buildClusterReconciler(ctx, conf, l, m, ms, seedClient)
 		},

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +29,11 @@ import (
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/metrics"
 	"github.com/gardener/logging/v1/pkg/targets"
+)
+
+const (
+	clusterCRDGroup = "extensions.gardener.cloud"
+	clusterCRDName  = "clusters.extensions.gardener.cloud"
 )
 
 var scheme = func() *runtime.Scheme {
@@ -81,6 +87,19 @@ func newClusterController(ctx context.Context, conf *config.Config, l logr.Logge
 		seedClient.StopWait()
 
 		return nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		seedClient.StopWait()
+
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	if err := waitForCRD(ctx, l, dynamicClient, clusterCRDGroup, clusterCRDName); err != nil {
+		seedClient.StopWait()
+
+		return nil, fmt.Errorf("failed waiting for CRD %s: %w", clusterCRDName, err)
 	}
 
 	ctlCtx, cancel := context.WithCancel(ctx)

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -126,22 +126,21 @@ func buildClusterReconciler(
 		Scheme: scheme,
 		Logger: l,
 		Cache: cache.Options{
-			// Restrict cache to Cluster objects only.
-			// This controller doesn't reconcile other types.
+			// Restrict cache to Cluster objects only; this controller does not reconcile other types.
 			ByObject: map[k8sclient.Object]cache.ByObject{
 				&extensionsv1alpha1.Cluster{}: {},
 			},
-			// Strip managed fields from all cached objects
-			// as they are not used by the reconciler.
+			// Strip managed fields from all cached objects as they are not used by the reconciler.
 			DefaultTransform: cache.TransformStripManagedFields(),
 		},
-		// Disable metrics and health probe servers
-		// since fluent-bit plugin handles these.
+		// Disable metrics and health probe servers since fluent-bit plugin handles these
 		Metrics:                ctrl.Options{}.Metrics,
 		HealthProbeBindAddress: "",
 	})
 	if err != nil {
 		cancel()
+		seedClient.StopWait()
+
 		return nil, fmt.Errorf("failed to create manager: %w", err)
 	}
 
@@ -164,6 +163,8 @@ func buildClusterReconciler(
 		Named(fmt.Sprintf("cluster-%s", uuid.NewUUID())).
 		Complete(reconciler); err != nil {
 		cancel()
+		seedClient.StopWait()
+
 		return nil, fmt.Errorf("failed to create controller: %w", err)
 	}
 
@@ -182,6 +183,8 @@ func buildClusterReconciler(
 
 	if !mgr.GetCache().WaitForCacheSync(syncCtx) {
 		cancel()
+		seedClient.StopWait()
+
 		return nil, errors.New("failed to wait for cache sync within timeout")
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -45,10 +45,12 @@ func NewController(
 ) (<-chan Controller, error) {
 	if conf.ControllerConfig.WatchOpenTelemetryCollector {
 		l.Info("using OpenTelemetryCollector mode for dynamic clients")
+
 		return newOpenTelemetryCollectorController(ctx, conf, l, m, ms)
 	}
 
 	l.Info("using Cluster mode for dynamic clients")
+
 	return newClusterController(ctx, conf, l, m, ms)
 }
 
@@ -76,5 +78,6 @@ func newDynamicClient() (dynamic.Interface, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST config: %w", err)
 	}
+
 	return dynamic.NewForConfig(restConfig)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -35,7 +35,7 @@ type Controller interface {
 // It sets up a manager and reconciler based on the configuration:
 // - If WatchOpenTelemetryCollector is true, it watches OpenTelemetryCollector resources
 // - Otherwise (default), it watches Cluster resources
-func NewController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (Controller, error) {
+func NewController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (<-chan Controller, error) {
 	if conf.ControllerConfig.WatchOpenTelemetryCollector {
 		l.Info("using OpenTelemetryCollector mode for dynamic clients")
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -65,4 +66,15 @@ func getRestConfig() (*rest.Config, error) {
 	}
 
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// newDynamicClient builds a dynamic.Interface against the in-cluster (or
+// KUBECONFIG) REST config. Extracted so reconcilers can construct one without
+// repeating the getRestConfig + dynamic.NewForConfig boilerplate.
+func newDynamicClient() (dynamic.Interface, error) {
+	restConfig, err := getRestConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+	return dynamic.NewForConfig(restConfig)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -35,15 +35,19 @@ type Controller interface {
 // It sets up a manager and reconciler based on the configuration:
 // - If WatchOpenTelemetryCollector is true, it watches OpenTelemetryCollector resources
 // - Otherwise (default), it watches Cluster resources
-func NewController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (<-chan Controller, error) {
+func NewController(
+	ctx context.Context,
+	conf *config.Config,
+	l logr.Logger,
+	m *metrics.FluentBitGardenerMetrics,
+	ms *otlp.MetricsSetup,
+) (<-chan Controller, error) {
 	if conf.ControllerConfig.WatchOpenTelemetryCollector {
 		l.Info("using OpenTelemetryCollector mode for dynamic clients")
-
 		return newOpenTelemetryCollectorController(ctx, conf, l, m, ms)
 	}
 
 	l.Info("using Cluster mode for dynamic clients")
-
 	return newClusterController(ctx, conf, l, m, ms)
 }
 

--- a/pkg/controller/otelcol_reconciler.go
+++ b/pkg/controller/otelcol_reconciler.go
@@ -93,7 +93,12 @@ func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Confi
 			conf.ControllerConfig.DynamicHostRegex, err)
 	}
 
-	return awaitController(ctx, l, otelcolScheme, &otelcolv1beta1.OpenTelemetryCollector{},
+	dynamicClient, err := newDynamicClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return awaitController(ctx, l, otelcolScheme, &otelcolv1beta1.OpenTelemetryCollector{}, dynamicClient,
 		func(ctx context.Context) (Controller, error) {
 			return buildOpenTelemetryCollectorReconciler(
 				ctx, conf, l, m, ms,

--- a/pkg/controller/otelcol_reconciler.go
+++ b/pkg/controller/otelcol_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +34,11 @@ import (
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/metrics"
 	"github.com/gardener/logging/v1/pkg/targets"
+)
+
+const (
+	otelcolCRDGroup = "opentelemetry.io"
+	otelcolCRDName  = "opentelemetrycollectors.opentelemetry.io"
 )
 
 var otelcolScheme = func() *runtime.Scheme {
@@ -93,6 +99,15 @@ func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Confi
 	restConfig, err := getRestConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	if err := waitForCRD(ctx, l, dynamicClient, otelcolCRDGroup, otelcolCRDName); err != nil {
+		return nil, fmt.Errorf("failed waiting for CRD %s: %w", otelcolCRDName, err)
 	}
 
 	ctlCtx, cancel := context.WithCancel(ctx)

--- a/pkg/controller/otelcol_reconciler.go
+++ b/pkg/controller/otelcol_reconciler.go
@@ -66,7 +66,9 @@ type otelCollectorReconciler struct {
 
 // newOpenTelemetryCollectorController creates a new Controller for OpenTelemetryCollector resources.
 // It sets up a manager and reconciler for OpenTelemetryCollector resources.
-func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (Controller, error) {
+func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (<-chan Controller, error) {
+	ch := make(chan Controller, 1)
+
 	// Parse the label selector for OpenTelemetryCollector resources
 	labelSelector, err := parseLabelSelector(conf.ControllerConfig.OpenTelemetryCollectorLabelSelector)
 	if err != nil {
@@ -170,7 +172,9 @@ func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Confi
 
 	l.Info("OpenTelemetryCollector controller started and cache synced")
 
-	return reconciler, nil
+	ch <- reconciler
+
+	return ch, nil
 }
 
 // buildLabelPredicate creates a predicate that filters OpenTelemetryCollector resources

--- a/pkg/controller/otelcol_reconciler.go
+++ b/pkg/controller/otelcol_reconciler.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,11 +33,6 @@ import (
 	"github.com/gardener/logging/v1/pkg/config"
 	"github.com/gardener/logging/v1/pkg/metrics"
 	"github.com/gardener/logging/v1/pkg/targets"
-)
-
-const (
-	otelcolCRDGroup = "opentelemetry.io"
-	otelcolCRDName  = "opentelemetrycollectors.opentelemetry.io"
 )
 
 var otelcolScheme = func() *runtime.Scheme {
@@ -71,10 +65,13 @@ type otelCollectorReconciler struct {
 }
 
 // newOpenTelemetryCollectorController creates a new Controller for OpenTelemetryCollector resources.
-// It sets up a manager and reconciler for OpenTelemetryCollector resources.
+//
+// Selectors and the DynamicHostRegex are parsed synchronously, then
+// awaitController watches the apiextensions API and, once the
+// OpenTelemetryCollector CRD is Established, builds the controller-runtime
+// manager and reconciler and delivers the resulting Controller on the
+// returned channel.
 func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Config, l logr.Logger, m *metrics.FluentBitGardenerMetrics, ms *otlp.MetricsSetup) (<-chan Controller, error) {
-	ch := make(chan Controller, 1)
-
 	// Parse the label selector for OpenTelemetryCollector resources
 	labelSelector, err := parseLabelSelector(conf.ControllerConfig.OpenTelemetryCollectorLabelSelector)
 	if err != nil {
@@ -96,18 +93,32 @@ func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Confi
 			conf.ControllerConfig.DynamicHostRegex, err)
 	}
 
+	return awaitController(ctx, l, otelcolScheme, &otelcolv1beta1.OpenTelemetryCollector{},
+		func(ctx context.Context) (Controller, error) {
+			return buildOpenTelemetryCollectorReconciler(
+				ctx, conf, l, m, ms,
+				labelSelector, namespaceLabelSelector, dynamicHostRegex,
+			)
+		},
+	)
+}
+
+// buildOpenTelemetryCollectorReconciler constructs the controller-runtime
+// manager and the otelCollectorReconciler. It is invoked by awaitController
+// once the OpenTelemetryCollector CRD is observed on the cluster.
+func buildOpenTelemetryCollectorReconciler(
+	ctx context.Context,
+	conf *config.Config,
+	l logr.Logger,
+	m *metrics.FluentBitGardenerMetrics,
+	ms *otlp.MetricsSetup,
+	labelSelector labels.Selector,
+	namespaceLabelSelector labels.Selector,
+	dynamicHostRegex *regexp.Regexp,
+) (Controller, error) {
 	restConfig, err := getRestConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST config: %w", err)
-	}
-
-	dynamicClient, err := dynamic.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
-	}
-
-	if err := waitForCRD(ctx, l, dynamicClient, otelcolCRDGroup, otelcolCRDName); err != nil {
-		return nil, fmt.Errorf("failed waiting for CRD %s: %w", otelcolCRDName, err)
 	}
 
 	ctlCtx, cancel := context.WithCancel(ctx)
@@ -187,9 +198,7 @@ func newOpenTelemetryCollectorController(ctx context.Context, conf *config.Confi
 
 	l.Info("OpenTelemetryCollector controller started and cache synced")
 
-	ch <- reconciler
-
-	return ch, nil
+	return reconciler, nil
 }
 
 // buildLabelPredicate creates a predicate that filters OpenTelemetryCollector resources

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -124,6 +124,9 @@ func isCRDEstablished(u *unstructured.Unstructured, group string) bool {
 			established = c.Status == apiextensionsv1.ConditionTrue
 		case apiextensionsv1.NamesAccepted:
 			namesAccepted = c.Status == apiextensionsv1.ConditionTrue
+		default:
+			// Other condition types (e.g. Terminating, KubernetesAPIApprovalPolicyConformant)
+			// don't gate readiness for our purposes.
 		}
 	}
 
@@ -198,9 +201,11 @@ func awaitController(
 		c, err := build(ctx)
 		if err != nil {
 			l.Error(err, "failed to build controller after CRD became available", "crd", crdName)
+
 			return
 		}
 		out <- c
 	}()
+
 	return out, nil
 }

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -130,9 +130,9 @@ func isCRDEstablished(u *unstructured.Unstructured, group string) bool {
 	return established && namesAccepted
 }
 
-// awaitController watches for the target CRD. Once that CRD is observed as
-// Established with its names accepted, it invokes `build` and delivers the
-// resulting Controller on the returned channel.
+// awaitController watches for the target CRD on the supplied dynamic client.
+// Once that CRD is observed as Established with its names accepted, it invokes
+// `build` and delivers the resulting Controller on the returned channel.
 //
 // The returned channel always closes — either after delivering the Controller,
 // or without a value if ctx is cancelled before the CRD shows up, or if `build` fails.
@@ -141,6 +141,7 @@ func awaitController(
 	l logr.Logger,
 	scheme *runtime.Scheme,
 	obj client.Object,
+	dynamicClient dynamic.Interface,
 	build func(ctx context.Context) (Controller, error),
 ) (<-chan Controller, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
@@ -149,16 +150,6 @@ func awaitController(
 	}
 	// CRD plural follows the kubebuilder convention of lowercasing the Kind and adding "s".
 	crdName := strings.ToLower(gvk.Kind) + "s." + gvk.Group
-
-	restConfig, err := getRestConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get REST config: %w", err)
-	}
-
-	dynamicClient, err := dynamic.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
-	}
 
 	factory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
 	informer := factory.ForResource(crdGVR).Informer()

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -21,6 +22,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	clientgocache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 func shootFromCluster(cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Shoot, error) {
@@ -127,58 +130,86 @@ func isCRDEstablished(u *unstructured.Unstructured, group string) bool {
 	return established && namesAccepted
 }
 
-// waitForCRD blocks until the CRD identified by (group, name) is observed as
-// Established with names accepted, or until ctx is cancelled.
+// awaitController watches for the target CRD. Once that CRD is observed as
+// Established with its names accepted, it invokes `build` and delivers the
+// resulting Controller on the returned channel.
 //
-// It runs a dynamic informer on CustomResourceDefinitions and stops it as soon
-// as the CRD shows up.
-func waitForCRD(ctx context.Context, l logr.Logger, dynamicClient dynamic.Interface, group, name string) error {
+// The returned channel always closes — either after delivering the Controller,
+// or without a value if ctx is cancelled before the CRD shows up, or if `build` fails.
+func awaitController(
+	ctx context.Context,
+	l logr.Logger,
+	scheme *runtime.Scheme,
+	obj client.Object,
+	build func(ctx context.Context) (Controller, error),
+) (<-chan Controller, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive GVK for %T: %w", obj, err)
+	}
+	// CRD plural follows the kubebuilder convention of lowercasing the Kind and adding "s".
+	crdName := strings.ToLower(gvk.Kind) + "s." + gvk.Group
+
+	restConfig, err := getRestConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
 	factory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
 	informer := factory.ForResource(crdGVR).Informer()
 
-	// Cancellable context drives the informer's lifecycle; we cancel it once the CRD shows up.
-	informerCtx, cancelInformer := context.WithCancel(ctx)
-	defer cancelInformer()
-
-	found := make(chan struct{})
 	var once sync.Once
-
-	check := func(obj any) {
-		u, ok := obj.(*unstructured.Unstructured)
+	found := make(chan struct{})
+	check := func(o any) {
+		u, ok := o.(*unstructured.Unstructured)
 		if !ok {
 			return
 		}
-		if u.GetName() != name {
+		if u.GetName() != crdName {
 			return
 		}
-		if !isCRDEstablished(u, group) {
+		if !isCRDEstablished(u, gvk.Group) {
 			return
 		}
 		once.Do(func() {
-			l.Info("target CRD is established, stopping informer", "crd", name)
+			l.Info("target CRD is established", "crd", crdName)
 			close(found)
 		})
 	}
-
 	if _, err := informer.AddEventHandler(clientgocache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj any) { check(obj) },
-		UpdateFunc: func(_, newObj any) { check(newObj) },
+		AddFunc:    func(o any) { check(o) },
+		UpdateFunc: func(_, o any) { check(o) },
 	}); err != nil {
-		return fmt.Errorf("failed to add event handler: %w", err)
+		return nil, fmt.Errorf("failed to add event handler: %w", err)
 	}
 
-	factory.Start(informerCtx.Done())
-	if !clientgocache.WaitForCacheSync(informerCtx.Done(), informer.HasSynced) {
-		return errors.New("failed to sync CRD informer cache")
+	factory.Start(ctx.Done())
+	if !clientgocache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return nil, errors.New("failed to sync CRD informer cache")
 	}
+	l.Info("waiting for CRD to become available", "crd", crdName)
 
-	l.Info("waiting for CRD to become available", "crd", name)
+	out := make(chan Controller, 1)
+	go func() {
+		defer close(out)
 
-	select {
-	case <-found:
-		// cancelInformer via defer shuts the informer down.
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+		select {
+		case <-found:
+		case <-ctx.Done():
+			return
+		}
+
+		c, err := build(ctx)
+		if err != nil {
+			l.Error(err, "failed to build controller after CRD became available", "crd", crdName)
+			return
+		}
+		out <- c
+	}()
+	return out, nil
 }

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -4,12 +4,23 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sync"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	clientgocache "k8s.io/client-go/tools/cache"
 )
 
 func shootFromCluster(cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Shoot, error) {
@@ -81,4 +92,93 @@ func getShootState(shoot *gardencorev1beta1.Shoot) clusterState {
 	}
 
 	return clusterStateReady
+}
+
+// crdGVR is the GroupVersionResource of the CustomResourceDefinition kind itself.
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+// isCRDEstablished returns true if the given CRD object is in group `group`,
+// is Established, and has its names accepted.
+func isCRDEstablished(u *unstructured.Unstructured, group string) bool {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, crd); err != nil {
+		return false
+	}
+
+	if crd.Spec.Group != group {
+		return false
+	}
+
+	established := false
+	namesAccepted := false
+	for _, c := range crd.Status.Conditions {
+		switch c.Type {
+		case apiextensionsv1.Established:
+			established = c.Status == apiextensionsv1.ConditionTrue
+		case apiextensionsv1.NamesAccepted:
+			namesAccepted = c.Status == apiextensionsv1.ConditionTrue
+		}
+	}
+
+	return established && namesAccepted
+}
+
+// waitForCRD blocks until the CRD identified by (group, name) is observed as
+// Established with names accepted, or until ctx is cancelled.
+//
+// It runs a dynamic informer on CustomResourceDefinitions and stops it as soon
+// as the CRD shows up.
+func waitForCRD(ctx context.Context, l logr.Logger, dynamicClient dynamic.Interface, group, name string) error {
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+	informer := factory.ForResource(crdGVR).Informer()
+
+	// Cancellable context drives the informer's lifecycle; we cancel it once the CRD shows up.
+	informerCtx, cancelInformer := context.WithCancel(ctx)
+	defer cancelInformer()
+
+	found := make(chan struct{})
+	var once sync.Once
+
+	check := func(obj any) {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return
+		}
+		if u.GetName() != name {
+			return
+		}
+		if !isCRDEstablished(u, group) {
+			return
+		}
+		once.Do(func() {
+			l.Info("target CRD is established, stopping informer", "crd", name)
+			close(found)
+		})
+	}
+
+	if _, err := informer.AddEventHandler(clientgocache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { check(obj) },
+		UpdateFunc: func(_, newObj any) { check(newObj) },
+	}); err != nil {
+		return fmt.Errorf("failed to add event handler: %w", err)
+	}
+
+	factory.Start(informerCtx.Done())
+	if !clientgocache.WaitForCacheSync(informerCtx.Done(), informer.HasSynced) {
+		return errors.New("failed to sync CRD informer cache")
+	}
+
+	l.Info("waiting for CRD to become available", "crd", name)
+
+	select {
+	case <-found:
+		// cancelInformer via defer shuts the informer down.
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"regexp"
+	"sync"
 
 	"github.com/go-logr/logr"
 
@@ -31,6 +32,7 @@ type logging struct {
 	cfg                             *config.Config
 	dynamicHostRegexp               *regexp.Regexp
 	extractKubernetesMetadataRegexp *regexp.Regexp
+	ctrlMu                          sync.RWMutex
 	controller                      controller.Controller
 	logger                          logr.Logger
 	ctx                             context.Context
@@ -59,11 +61,27 @@ func NewPlugin(cfg *config.Config, logger logr.Logger, m *metrics.FluentBitGarde
 		l.dynamicHostRegexp = regexp.MustCompile(cfg.ControllerConfig.DynamicHostRegex)
 
 		// Pass the plugin's context to the controller
-		if l.controller, err = controller.NewController(ctx, cfg, logger, m, ms); err != nil {
+		ctlCh, err := controller.NewController(ctx, cfg, logger, m, ms)
+		if err != nil {
 			cancel()
 
 			return nil, err
 		}
+
+		// The controller is delivered asynchronously: the plugin starts without
+		// one and routes dynamic-host records to nil (dropped) until it arrives.
+		// getClient handles the nil case.
+		go func() {
+			select {
+			case c, ok := <-ctlCh:
+				if !ok {
+					return
+				}
+				l.setController(c)
+				logger.Info("controller installed in plugin")
+			case <-ctx.Done():
+			}
+		}()
 	}
 
 	if cfg.PluginConfig.KubernetesMetadata.FallbackToTagWhenMetadataIsMissing {
@@ -96,13 +114,13 @@ func NewPluginWithController(cfg *config.Config, logger logr.Logger, m *metrics.
 	ctx, cancel := context.WithCancel(context.Background())
 
 	l := &logging{
-		cfg:        cfg,
-		logger:     logger,
-		ctx:        ctx,
-		cancel:     cancel,
-		controller: ctl,
-		metrics:    m,
+		cfg:     cfg,
+		logger:  logger,
+		ctx:     ctx,
+		cancel:  cancel,
+		metrics: m,
 	}
+	l.setController(ctl)
 
 	if len(cfg.ControllerConfig.DynamicHostPath) > 0 {
 		l.dynamicHostRegexp = regexp.MustCompile(cfg.ControllerConfig.DynamicHostRegex)
@@ -207,8 +225,8 @@ func (l *logging) Close() {
 	l.cancel()
 
 	l.seedClient.StopWait()
-	if l.controller != nil {
-		l.controller.Stop()
+	if c := l.getController(); c != nil {
+		c.Stop()
 	}
 
 	l.logger.Info("logging plugin stopped",
@@ -218,15 +236,32 @@ func (l *logging) Close() {
 }
 
 func (l *logging) getClient(dynamicHosName string) api.Output {
-	if l.isDynamicHost(dynamicHosName) && l.controller != nil {
-		if c, isStopped := l.controller.GetClient(dynamicHosName); !isStopped {
-			return c
+	if l.isDynamicHost(dynamicHosName) {
+		c := l.getController()
+		if c == nil {
+			return nil
+		}
+		if out, isStopped := c.GetClient(dynamicHosName); !isStopped {
+			return out
 		}
 
 		return nil
 	}
 
 	return l.seedClient
+}
+
+func (l *logging) getController() controller.Controller {
+	l.ctrlMu.RLock()
+	defer l.ctrlMu.RUnlock()
+
+	return l.controller
+}
+
+func (l *logging) setController(c controller.Controller) {
+	l.ctrlMu.Lock()
+	defer l.ctrlMu.Unlock()
+	l.controller = c
 }
 
 func (l *logging) isDynamicHost(dynamicHostName string) bool {

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -68,9 +68,9 @@ func NewPlugin(cfg *config.Config, logger logr.Logger, m *metrics.FluentBitGarde
 			return nil, err
 		}
 
-		// The controller is delivered asynchronously: the plugin starts without
-		// one and routes dynamic-host records to nil (dropped) until it arrives.
-		// getClient handles the nil case.
+		// The controller is delivered asynchronously (it waits for its CRD to be
+		// established). Until it arrives, getClient routes dynamic-host records
+		// to the seed client as a fallback so they are not dropped.
 		go func() {
 			select {
 			case c, ok := <-ctlCh:
@@ -239,7 +239,9 @@ func (l *logging) getClient(dynamicHosName string) api.Output {
 	if l.isDynamicHost(dynamicHosName) {
 		c := l.getController()
 		if c == nil {
-			return nil
+			// Controller not yet available (e.g. CRD not installed).
+			// Fall back to the seed client so records aren't dropped.
+			return l.seedClient
 		}
 		if out, isStopped := c.GetClient(dynamicHosName); !isStopped {
 			return out

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -114,13 +114,13 @@ func NewPluginWithController(cfg *config.Config, logger logr.Logger, m *metrics.
 	ctx, cancel := context.WithCancel(context.Background())
 
 	l := &logging{
-		cfg:     cfg,
-		logger:  logger,
-		ctx:     ctx,
-		cancel:  cancel,
-		metrics: m,
+		cfg:        cfg,
+		logger:     logger,
+		ctx:        ctx,
+		cancel:     cancel,
+		controller: ctl,
+		metrics:    m,
 	}
-	l.setController(ctl)
 
 	if len(cfg.ControllerConfig.DynamicHostPath) > 0 {
 		l.dynamicHostRegexp = regexp.MustCompile(cfg.ControllerConfig.DynamicHostRegex)

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -78,6 +78,7 @@ func NewPlugin(cfg *config.Config, logger logr.Logger, m *metrics.FluentBitGarde
 			case c, ok := <-ctlCh:
 				if !ok {
 					logger.Info("controller channel closed before delivery; staying in seed-client fallback mode")
+
 					return
 				}
 				l.setController(c)
@@ -247,6 +248,7 @@ func (l *logging) getClient(dynamicHosName string) api.Output {
 			l.logger.Info("controller not installed yet, routing dynamic-host record to seed client",
 				"host", dynamicHosName,
 			)
+
 			return l.seedClient
 		}
 		if out, isStopped := c.GetClient(dynamicHosName); !isStopped {

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -71,14 +71,17 @@ func NewPlugin(cfg *config.Config, logger logr.Logger, m *metrics.FluentBitGarde
 		// The controller is delivered asynchronously (it waits for its CRD to be
 		// established). Until it arrives, getClient routes dynamic-host records
 		// to the seed client as a fallback so they are not dropped.
+		logger.Info("controller pending: dynamic-host records will fall back to the seed client until the CRD is established")
+
 		go func() {
 			select {
 			case c, ok := <-ctlCh:
 				if !ok {
+					logger.Info("controller channel closed before delivery; staying in seed-client fallback mode")
 					return
 				}
 				l.setController(c)
-				logger.Info("controller installed in plugin")
+				logger.Info("controller installed in plugin: dynamic-host records now route through the controller (fallback ended)")
 			case <-ctx.Done():
 			}
 		}()
@@ -241,6 +244,9 @@ func (l *logging) getClient(dynamicHosName string) api.Output {
 		if c == nil {
 			// Controller not yet available (e.g. CRD not installed).
 			// Fall back to the seed client so records aren't dropped.
+			l.logger.V(1).Info("controller not installed yet, routing dynamic-host record to seed client",
+				"host", dynamicHosName,
+			)
 			return l.seedClient
 		}
 		if out, isStopped := c.GetClient(dynamicHosName); !isStopped {

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -244,7 +244,7 @@ func (l *logging) getClient(dynamicHosName string) api.Output {
 		if c == nil {
 			// Controller not yet available (e.g. CRD not installed).
 			// Fall back to the seed client so records aren't dropped.
-			l.logger.V(1).Info("controller not installed yet, routing dynamic-host record to seed client",
+			l.logger.Info("controller not installed yet, routing dynamic-host record to seed client",
 				"host", dynamicHosName,
 			)
 			return l.seedClient

--- a/pkg/plugin/logging_test.go
+++ b/pkg/plugin/logging_test.go
@@ -376,20 +376,40 @@ var _ = Describe("OutputPlugin plugin", func() {
 		// Mirrors the awaitController flow at the plugin layer: until the
 		// controller is delivered, dynamic-host records fall back to the seed
 		// client; once it arrives, the plugin routes through it.
+		//
+		// Uses NewPluginWithController(ctl=nil) to avoid spinning up the real
+		// controller-runtime path inside NewPlugin, which needs an in-cluster
+		// or KUBECONFIG-based REST config and so fails in CI.
 		It("falls back to the seed client for dynamic hosts until the controller is installed", func() {
-			cfg.ControllerConfig = config.ControllerConfig{
-				CtlSyncTimeout:    5 * time.Second,
-				DynamicHostPrefix: "http://logging.",
-				DynamicHostSuffix: ".svc:4318/v1/logs",
-				DynamicHostRegex:  `^shoot--.*`,
-				DynamicHostPath: map[string]any{
-					"kubernetes": map[string]any{
-						"namespace_name": "namespace",
+			cfg := &config.Config{
+				OTLPConfig: config.OTLPConfig{
+					Endpoint: "http://test-seed-endpoint:4318/v1/logs",
+					DQueConfig: config.DQueConfig{
+						DQueDir:         GinkgoT().TempDir(),
+						DQueSegmentSize: 500,
+						DQueSync:        false,
+						DQueName:        fmt.Sprintf("dque-fallback-%d", time.Now().UnixNano()),
+					},
+				},
+				PluginConfig: config.PluginConfig{
+					SeedType:  types.NOOP.String(),
+					ShootType: types.NOOP.String(),
+					LogLevel:  "info",
+				},
+				ControllerConfig: config.ControllerConfig{
+					CtlSyncTimeout:    5 * time.Second,
+					DynamicHostPrefix: "http://logging.",
+					DynamicHostSuffix: ".svc:4318/v1/logs",
+					DynamicHostRegex:  `^shoot--.*`,
+					DynamicHostPath: map[string]any{
+						"kubernetes": map[string]any{
+							"namespace_name": "namespace",
+						},
 					},
 				},
 			}
 
-			plugin, err := NewPlugin(cfg, logger, testMetrics, nil)
+			plugin, err := NewPluginWithController(cfg, logger, testMetrics, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			defer plugin.Close()
 

--- a/pkg/plugin/logging_test.go
+++ b/pkg/plugin/logging_test.go
@@ -376,10 +376,6 @@ var _ = Describe("OutputPlugin plugin", func() {
 		// Mirrors the awaitController flow at the plugin layer: until the
 		// controller is delivered, dynamic-host records fall back to the seed
 		// client; once it arrives, the plugin routes through it.
-		//
-		// Uses NewPluginWithController(ctl=nil) to avoid spinning up the real
-		// controller-runtime path inside NewPlugin, which needs an in-cluster
-		// or KUBECONFIG-based REST config and so fails in CI.
 		It("falls back to the seed client for dynamic hosts until the controller is installed", func() {
 			cfg := &config.Config{
 				OTLPConfig: config.OTLPConfig{

--- a/pkg/plugin/logging_test.go
+++ b/pkg/plugin/logging_test.go
@@ -30,6 +30,32 @@ import (
 	"github.com/gardener/logging/v1/pkg/types"
 )
 
+// stubOutput is a no-op api.Output used to assert routing in plugin tests
+// without involving any real client machinery.
+type stubOutput struct {
+	name string
+}
+
+func (*stubOutput) Handle(_ types.OutputEntry) error { return nil }
+func (*stubOutput) Stop()                            {}
+func (*stubOutput) StopWait()                        {}
+func (s *stubOutput) Endpoint() string               { return s.name }
+
+// stubController is a controller.Controller used to verify that the plugin
+// routes dynamic-host records through the controller once it is installed.
+type stubController struct {
+	clients map[string]api.Output
+}
+
+// GetClient mirrors the real reconcilers' contract.
+func (s *stubController) GetClient(name string) (api.Output, bool) {
+	return s.clients[name], false
+}
+func (*stubController) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+func (*stubController) Stop() {}
+
 var _ = Describe("OutputPlugin plugin", func() {
 	var (
 		cfg         *config.Config
@@ -345,6 +371,50 @@ var _ = Describe("OutputPlugin plugin", func() {
 			Expect(l.isDynamicHost("")).To(BeFalse())
 			Expect(l.isDynamicHost("random-name")).To(BeFalse())
 			Expect(l.isDynamicHost("garden")).To(BeFalse())
+		})
+
+		// Mirrors the awaitController flow at the plugin layer: until the
+		// controller is delivered, dynamic-host records fall back to the seed
+		// client; once it arrives, the plugin routes through it.
+		It("falls back to the seed client for dynamic hosts until the controller is installed", func() {
+			cfg.ControllerConfig = config.ControllerConfig{
+				CtlSyncTimeout:    5 * time.Second,
+				DynamicHostPrefix: "http://logging.",
+				DynamicHostSuffix: ".svc:4318/v1/logs",
+				DynamicHostRegex:  `^shoot--.*`,
+				DynamicHostPath: map[string]any{
+					"kubernetes": map[string]any{
+						"namespace_name": "namespace",
+					},
+				},
+			}
+
+			plugin, err := NewPlugin(cfg, logger, testMetrics, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer plugin.Close()
+
+			l, ok := plugin.(*logging)
+			Expect(ok).To(BeTrue())
+			Expect(l.seedClient).NotTo(BeNil())
+			Expect(l.getController()).To(BeNil(), "no controller is installed yet")
+
+			// Phase 1: CRD not yet established, controller not installed.
+			// A dynamic-host record must be routed to the seed client rather than dropped.
+			const dynamicHost = "shoot--proj--cluster"
+			Expect(l.isDynamicHost(dynamicHost)).To(BeTrue())
+			Expect(l.getClient(dynamicHost)).To(BeIdenticalTo(l.seedClient))
+
+			// Phase 2: simulate awaitController delivering the controller.
+			shootClient := &stubOutput{name: "shoot-client"}
+			l.setController(&stubController{clients: map[string]api.Output{dynamicHost: shootClient}})
+
+			// Same dynamic host now resolves through the controller.
+			got := l.getClient(dynamicHost)
+			Expect(got).To(BeIdenticalTo(api.Output(shootClient)))
+			Expect(got).NotTo(BeIdenticalTo(l.seedClient))
+
+			// Non-dynamic hosts continue to use the seed client either way.
+			Expect(l.getClient("garden")).To(BeIdenticalTo(l.seedClient))
 		})
 	})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/area logging

**What this PR does / why we need it**:
Currently, the Fluent Bit plugin depends on two CRDs to determine the correct log destination based on the environment in which it is deployed:
* `Clusters` from the `extensions.gardener.cloud` API group
* `OpenTelemetryCollector` from the `opentelemetry.io` API group

Previously, if the plugin was deployed before the required CRD became available, it would fail to start and crash. While this was partially mitigated in the Gardener environment because the fluent-operator continuously restarts failed processes until the CRD appears, relying on restart retries is not a robust solution. In certain scenarios, this behavior could lead to instability and potential log loss.

To address this issue, a CRD availability watch mechanism has been introduced for both dependencies. When the required CRD is not available, the plugin automatically routes logs to a fallback OTLP backend, which corresponds to the seed's logging stack. Once the required CRD becomes available, the plugin dynamically switches traffic to the intended destination without requiring a restart.

This approach significantly improves resilience and reliability by eliminating the dependency on repeated process restarts. It also makes the plugin more flexible across different deployment scenarios, ensuring predictable behavior regardless of the order in which components and CRDs become available.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Improved Fluent Bit resilience by adding dynamic CRD detection and automatic fallback log routing, preventing startup failures when required CRDs are not yet available.
```
