### PR TITLE
Update copyright text

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,13 +6,13 @@ SPDX-PackageDownloadLocation = "https://github.com/gardener/logging"
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**.md"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]
@@ -20,5 +20,5 @@ path = ["cmd/fluent-bit-output-plugin/output_plugin.go", "pkg/config/config.go",
 "pkg/config/client_config.go", "pkg/plugin/vali.go", "pkg/plugin/utils.go", "pkg/client/buffer_client.go",
 "pkg/client/dque.go", "pkg/client/buffer.go"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,13 +6,13 @@ SPDX-PackageDownloadLocation = "https://github.com/gardener/logging"
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2017-2024 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**.md"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2017-2024 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]
@@ -20,5 +20,5 @@ path = ["cmd/fluent-bit-output-plugin/output_plugin.go", "pkg/config/config.go",
 "pkg/config/client_config.go", "pkg/plugin/vali.go", "pkg/plugin/utils.go", "pkg/client/buffer_client.go",
 "pkg/client/dque.go", "pkg/client/buffer.go"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2017-2024 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/event-logger/app/options.go
+++ b/cmd/event-logger/app/options.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cmd/event-logger/app/options.go
+++ b/cmd/event-logger/app/options.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cmd/event-logger/main.go
+++ b/cmd/event-logger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/event-logger/main.go
+++ b/cmd/event-logger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/config_dump.go
+++ b/cmd/fluent-bit-output-plugin/config_dump.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/config_dump.go
+++ b/cmd/fluent-bit-output-plugin/config_dump.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/output_plugin.go
+++ b/cmd/fluent-bit-output-plugin/output_plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/output_plugin.go
+++ b/cmd/fluent-bit-output-plugin/output_plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/output_plugin.h
+++ b/cmd/fluent-bit-output-plugin/output_plugin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 SAP SE or an SAP affiliate company and Gardener contributors
+ * Copyright Copyright Contributors to the Gardener project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cmd/fluent-bit-output-plugin/output_plugin.h
+++ b/cmd/fluent-bit-output-plugin/output_plugin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright Copyright Contributors to the Gardener project
+ * Copyright Contributors to the Gardener project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cmd/fluent-bit-output-plugin/output_plugin.h
+++ b/cmd/fluent-bit-output-plugin/output_plugin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright Contributors to the Gardener project
+ * Contributors to the Gardener project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cmd/fluent-bit-output-plugin/plugin_config.go
+++ b/cmd/fluent-bit-output-plugin/plugin_config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/plugin_config.go
+++ b/cmd/fluent-bit-output-plugin/plugin_config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/pprof.go
+++ b/cmd/fluent-bit-output-plugin/pprof.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/pprof.go
+++ b/cmd/fluent-bit-output-plugin/pprof.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/record_converter.go
+++ b/cmd/fluent-bit-output-plugin/record_converter.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/record_converter.go
+++ b/cmd/fluent-bit-output-plugin/record_converter.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/record_converter_test.go
+++ b/cmd/fluent-bit-output-plugin/record_converter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/fluent-bit-output-plugin/record_converter_test.go
+++ b/cmd/fluent-bit-output-plugin/record_converter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/example/performance-test/check.sh
+++ b/example/performance-test/check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/check.sh
+++ b/example/performance-test/check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/clean.sh
+++ b/example/performance-test/clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/clean.sh
+++ b/example/performance-test/clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/down.sh
+++ b/example/performance-test/down.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/down.sh
+++ b/example/performance-test/down.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/fetch.sh
+++ b/example/performance-test/fetch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 set -eo pipefail

--- a/example/performance-test/fetch.sh
+++ b/example/performance-test/fetch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 set -eo pipefail

--- a/example/performance-test/run.sh
+++ b/example/performance-test/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/run.sh
+++ b/example/performance-test/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/setup.sh
+++ b/example/performance-test/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/example/performance-test/setup.sh
+++ b/example/performance-test/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/.includes.sh
+++ b/hack/.includes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/.includes.sh
+++ b/hack/.includes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/add-license-header.sh
+++ b/hack/add-license-header.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 
 set -e
 root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
-COPYRIGHT="SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors"
+COPYRIGHT="SPDX-FileCopyrightText: Copyright Contributors to the Gardener project"
 
 go tool -modfile=${root_dir}/tools/go.mod addlicense \
   -c "$COPYRIGHT" \

--- a/hack/add-license-header.sh
+++ b/hack/add-license-header.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 
 set -e
 root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
-COPYRIGHT="SPDX-FileCopyrightText: Copyright Contributors to the Gardener project"
+COPYRIGHT="SPDX-FileCopyrightText: Contributors to the Gardener project"
 
 go tool -modfile=${root_dir}/tools/go.mod addlicense \
   -c "$COPYRIGHT" \

--- a/hack/docker-image-build.sh
+++ b/hack/docker-image-build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/docker-image-build.sh
+++ b/hack/docker-image-build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/docker-image-push.sh
+++ b/hack/docker-image-push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/docker-image-push.sh
+++ b/hack/docker-image-push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+# Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,4 +1,4 @@
-// Copyright 2026 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2026 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,4 +1,4 @@
-// Copyright 2026 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2026 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/client/api/interface.go
+++ b/pkg/client/api/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package api

--- a/pkg/client/api/interface.go
+++ b/pkg/client/api/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package api

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package client

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package client

--- a/pkg/client/client_suit_test.go
+++ b/pkg/client/client_suit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package client_test

--- a/pkg/client/client_suit_test.go
+++ b/pkg/client/client_suit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package client_test

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package client

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package client

--- a/pkg/client/noop/noop_client.go
+++ b/pkg/client/noop/noop_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/client/noop/noop_client.go
+++ b/pkg/client/noop/noop_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/client/noop/noop_client_test.go
+++ b/pkg/client/noop/noop_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package noop

--- a/pkg/client/noop/noop_client_test.go
+++ b/pkg/client/noop/noop_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package noop

--- a/pkg/client/otlp/batch_processor_factory.go
+++ b/pkg/client/otlp/batch_processor_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/batch_processor_factory.go
+++ b/pkg/client/otlp/batch_processor_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/batch_processor_factory_test.go
+++ b/pkg/client/otlp/batch_processor_factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/batch_processor_factory_test.go
+++ b/pkg/client/otlp/batch_processor_factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/dque_batch_processor.go
+++ b/pkg/client/otlp/dque_batch_processor.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/dque_batch_processor.go
+++ b/pkg/client/otlp/dque_batch_processor.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/dque_batch_processor_test.go
+++ b/pkg/client/otlp/dque_batch_processor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp_test

--- a/pkg/client/otlp/dque_batch_processor_test.go
+++ b/pkg/client/otlp/dque_batch_processor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp_test

--- a/pkg/client/otlp/errors.go
+++ b/pkg/client/otlp/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/errors.go
+++ b/pkg/client/otlp/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/log_record_builder.go
+++ b/pkg/client/otlp/log_record_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/log_record_builder.go
+++ b/pkg/client/otlp/log_record_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/log_record_builder_test.go
+++ b/pkg/client/otlp/log_record_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/log_record_builder_test.go
+++ b/pkg/client/otlp/log_record_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/metrics_setup.go
+++ b/pkg/client/otlp/metrics_setup.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 // Package otlp provides OTLP client implementations with integrated metrics collection.

--- a/pkg/client/otlp/metrics_setup.go
+++ b/pkg/client/otlp/metrics_setup.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 // Package otlp provides OTLP client implementations with integrated metrics collection.

--- a/pkg/client/otlp/metrics_setup_test.go
+++ b/pkg/client/otlp/metrics_setup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/metrics_setup_test.go
+++ b/pkg/client/otlp/metrics_setup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/otlpgrpc/config_builder.go
+++ b/pkg/client/otlp/otlpgrpc/config_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlpgrpc

--- a/pkg/client/otlp/otlpgrpc/config_builder.go
+++ b/pkg/client/otlp/otlpgrpc/config_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlpgrpc

--- a/pkg/client/otlp/otlpgrpc/otlpgrpc_client.go
+++ b/pkg/client/otlp/otlpgrpc/otlpgrpc_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlpgrpc

--- a/pkg/client/otlp/otlpgrpc/otlpgrpc_client.go
+++ b/pkg/client/otlp/otlpgrpc/otlpgrpc_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlpgrpc

--- a/pkg/client/otlp/otlpgrpc/otlpgrpc_client_test.go
+++ b/pkg/client/otlp/otlpgrpc/otlpgrpc_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlpgrpc_test

--- a/pkg/client/otlp/otlpgrpc/otlpgrpc_client_test.go
+++ b/pkg/client/otlp/otlpgrpc/otlpgrpc_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlpgrpc_test

--- a/pkg/client/otlp/otlphttp/config_builder.go
+++ b/pkg/client/otlp/otlphttp/config_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlphttp

--- a/pkg/client/otlp/otlphttp/config_builder.go
+++ b/pkg/client/otlp/otlphttp/config_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlphttp

--- a/pkg/client/otlp/otlphttp/otlphttp_client.go
+++ b/pkg/client/otlp/otlphttp/otlphttp_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlphttp

--- a/pkg/client/otlp/otlphttp/otlphttp_client.go
+++ b/pkg/client/otlp/otlphttp/otlphttp_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlphttp

--- a/pkg/client/otlp/otlphttp/otlphttp_client_test.go
+++ b/pkg/client/otlp/otlphttp/otlphttp_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlphttp_test

--- a/pkg/client/otlp/otlphttp/otlphttp_client_test.go
+++ b/pkg/client/otlp/otlphttp/otlphttp_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlphttp_test

--- a/pkg/client/otlp/resource_attributes.go
+++ b/pkg/client/otlp/resource_attributes.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/resource_attributes.go
+++ b/pkg/client/otlp/resource_attributes.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/resource_attributes_test.go
+++ b/pkg/client/otlp/resource_attributes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp_test

--- a/pkg/client/otlp/resource_attributes_test.go
+++ b/pkg/client/otlp/resource_attributes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp_test

--- a/pkg/client/otlp/scope_attributes.go
+++ b/pkg/client/otlp/scope_attributes.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/scope_attributes.go
+++ b/pkg/client/otlp/scope_attributes.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/scope_attributes_test.go
+++ b/pkg/client/otlp/scope_attributes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp_test

--- a/pkg/client/otlp/scope_attributes_test.go
+++ b/pkg/client/otlp/scope_attributes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp_test

--- a/pkg/client/otlp/severity.go
+++ b/pkg/client/otlp/severity.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/otlp/severity.go
+++ b/pkg/client/otlp/severity.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package otlp

--- a/pkg/client/stdout/stdout_client.go
+++ b/pkg/client/stdout/stdout_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package stdout

--- a/pkg/client/stdout/stdout_client.go
+++ b/pkg/client/stdout/stdout_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package stdout

--- a/pkg/client/stdout/stdout_client_test.go
+++ b/pkg/client/stdout/stdout_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package stdout

--- a/pkg/client/stdout/stdout_client_test.go
+++ b/pkg/client/stdout/stdout_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package stdout

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 package config
 

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 package config
 

--- a/pkg/config/plugin.go
+++ b/pkg/config/plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/plugin.go
+++ b/pkg/config/plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/controller/awaitcontroller_test.go
+++ b/pkg/controller/awaitcontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2026 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/awaitcontroller_test.go
+++ b/pkg/controller/awaitcontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2026 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/client_test.go
+++ b/pkg/controller/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/client_test.go
+++ b/pkg/controller/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/cluster_reconciler.go
+++ b/pkg/controller/cluster_reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller_test

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller_test

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/otelcol_reconciler.go
+++ b/pkg/controller/otelcol_reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/otelcol_reconciler.go
+++ b/pkg/controller/otelcol_reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/otelcol_reconciler_test.go
+++ b/pkg/controller/otelcol_reconciler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/otelcol_reconciler_test.go
+++ b/pkg/controller/otelcol_reconciler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package controller

--- a/pkg/events/events_logger.go
+++ b/pkg/events/events_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/events/events_logger.go
+++ b/pkg/events/events_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/events/gardener_event_watcher.go
+++ b/pkg/events/gardener_event_watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/events/gardener_event_watcher.go
+++ b/pkg/events/gardener_event_watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/events/options.go
+++ b/pkg/events/options.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/events/options.go
+++ b/pkg/events/options.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package events

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package healthz

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package healthz

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package log // nolint:revive // package naming is intentional

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package log // nolint:revive // package naming is intentional

--- a/pkg/metrics/key_types.go
+++ b/pkg/metrics/key_types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/metrics/key_types.go
+++ b/pkg/metrics/key_types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics_test

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics_test

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics_test

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics_test

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin // nolint:revive // var-naming the plugin package is the main entry point

--- a/pkg/plugin/logging.go
+++ b/pkg/plugin/logging.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin // nolint:revive // var-naming the plugin package is the main entry point

--- a/pkg/plugin/logging_suite_test.go
+++ b/pkg/plugin/logging_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin_test

--- a/pkg/plugin/logging_suite_test.go
+++ b/pkg/plugin/logging_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin_test

--- a/pkg/plugin/logging_test.go
+++ b/pkg/plugin/logging_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/plugin/logging_test.go
+++ b/pkg/plugin/logging_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/plugin/plugin_registry.go
+++ b/pkg/plugin/plugin_registry.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/plugin/plugin_registry.go
+++ b/pkg/plugin/plugin_registry.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/plugin/plugin_registry_test.go
+++ b/pkg/plugin/plugin_registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/plugin/plugin_registry_test.go
+++ b/pkg/plugin/plugin_registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin // nolint:revive // var-naming the plugin package is the main entry point

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin // nolint:revive // var-naming the plugin package is the main entry point

--- a/pkg/plugin/utils_test.go
+++ b/pkg/plugin/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/plugin/utils_test.go
+++ b/pkg/plugin/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/pkg/targets/targets.go
+++ b/pkg/targets/targets.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/targets/targets.go
+++ b/pkg/targets/targets.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:revive // var-naming: package name "types" is acceptable for this types definition package

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:revive // var-naming: package name "types" is acceptable for this types definition package

--- a/tests/e2e/query_helpers.go
+++ b/tests/e2e/query_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/tests/e2e/query_helpers.go
+++ b/tests/e2e/query_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/tests/e2e/setup.go
+++ b/tests/e2e/setup.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/tests/e2e/setup.go
+++ b/tests/e2e/setup.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/tests/e2e/systemd_test.go
+++ b/tests/e2e/systemd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/tests/e2e/systemd_test.go
+++ b/tests/e2e/systemd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/tests/plugin/plugin_suite_test.go
+++ b/tests/plugin/plugin_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin_test

--- a/tests/plugin/plugin_suite_test.go
+++ b/tests/plugin/plugin_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin_test

--- a/tests/plugin/plugin_test.go
+++ b/tests/plugin/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 // Package plugin contains integration tests for the Gardener logging output plugin.

--- a/tests/plugin/plugin_test.go
+++ b/tests/plugin/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 // Package plugin contains integration tests for the Gardener logging output plugin.

--- a/tests/plugin/simple_test.go
+++ b/tests/plugin/simple_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin

--- a/tests/plugin/simple_test.go
+++ b/tests/plugin/simple_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+// Copyright 2025 SPDX-FileCopyrightText: Contributors to the Gardener project
 // SPDX-License-Identifier: Apache-2.0
 
 package plugin


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the SPDX copyright text from `SAP SE or an SAP affiliate company and Gardener contributors` to `Contributors to the Gardener project` across all files.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```