### PR TITLE
fix: drop stale config keys and wire missing config options

### DIFF
--- a/cmd/fluent-bit-output-plugin/plugin_config.go
+++ b/cmd/fluent-bit-output-plugin/plugin_config.go
@@ -54,7 +54,7 @@ func (c *pluginConfig) toStringMap() map[string]string {
 		"DQueDir", "dqueDir", "dque_dir",
 		"DQueSegmentSize", "dqueSegmentSize", "dque_segment_size",
 		"DQueSync", "dqueSync", "dque_sync",
-		"DQueName", " dqueName", "dque_name",
+		"DQueName", "dqueName", "dque_name",
 
 		// Controller config
 		"DeletedClientTimeExpiration", "deletedClientTimeExpiration", "deleted_client_time_expiration",
@@ -91,7 +91,7 @@ func (c *pluginConfig) toStringMap() map[string]string {
 		// Common OTLP configs
 		"Endpoint", "endpoint",
 		"EndpointUrl", "endpointUrl", "endpoint_url",
-		"EndpointUrlPath:", "endpointUrlPath", "endpoint_url_path",
+		"EndpointUrlPath", "endpointUrlPath", "endpoint_url_path",
 		"Insecure", "insecure",
 		"Compression", "compression",
 		"Timeout", "timeout",

--- a/cmd/fluent-bit-output-plugin/plugin_config.go
+++ b/cmd/fluent-bit-output-plugin/plugin_config.go
@@ -103,7 +103,6 @@ func (c *pluginConfig) toStringMap() map[string]string {
 		"RetryMaxElapsedTime", "retryMaxElapsedTime", "retry_max_elapsed_time",
 
 		// OTLP HTTP specific configs
-		"HTTPPath", "httpPath", "http_path",
 		"HTTPProxy", "httpProxy", "http_proxy",
 
 		// OTLP TLS configs

--- a/cmd/fluent-bit-output-plugin/plugin_config.go
+++ b/cmd/fluent-bit-output-plugin/plugin_config.go
@@ -57,7 +57,6 @@ func (c *pluginConfig) toStringMap() map[string]string {
 		"DQueName", "dqueName", "dque_name",
 
 		// Controller config
-		"DeletedClientTimeExpiration", "deletedClientTimeExpiration", "deleted_client_time_expiration",
 		"ControllerSyncTimeout", "controllerSyncTimeout", "controller_sync_timeout",
 
 		// OpenTelemetryCollector watching config

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,7 +112,6 @@ As an alternative to the default DQue-based batch processor, you can use the OTE
 | `DynamicHostSuffix` | Suffix for dynamic host URL | `""` | string |
 | `DynamicHostRegex` | Regex to validate dynamic host | `*` | string |
 | `ControllerSyncTimeout` | Time to wait for cluster object sync | `60s` | duration |
-| `DeletedClientTimeExpiration` | Expiration time for deleted cluster clients | `1h` | duration |
 
 ### Cluster State-Based Routing
 
@@ -253,7 +252,6 @@ Route logs to different backends based on Shoot cluster namespaces:
     
     # Controller settings
     ControllerSyncTimeout 60s
-    DeletedClientTimeExpiration 1h
 ```
 
 ### Development/Debug Configuration

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -118,10 +118,6 @@ This document provides solutions to common issues when using the Gardener Fluent
 
 3. **Too many clients**:
    - Check for client leaks with dynamic routing
-   - Review client cleanup:
-   ```ini
-   DeletedClientTimeExpiration 30m
-   ```
 
 4. **Memory leak**:
    - Enable profiling and analyze heap:

--- a/pkg/client/otlp/otlphttp/config_builder.go
+++ b/pkg/client/otlp/otlphttp/config_builder.go
@@ -4,6 +4,9 @@
 package otlphttp
 
 import (
+	"net/http"
+	"net/url"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 
 	"github.com/gardener/logging/v1/pkg/config"
@@ -29,6 +32,7 @@ func (b *ConfigBuilder) Build() []otlploghttp.Option {
 	b.configureTimeout(&opts)
 	b.configureCompression(&opts)
 	b.configureRetry(&opts)
+	b.configureProxy(&opts)
 
 	return opts
 }
@@ -79,4 +83,19 @@ func (b *ConfigBuilder) configureEndpoint(opts *[]otlploghttp.Option) {
 	} else {
 		*opts = append(*opts, otlploghttp.WithEndpoint(b.cfg.OTLPConfig.Endpoint))
 	}
+}
+
+func (b *ConfigBuilder) configureProxy(opts *[]otlploghttp.Option) {
+	if b.cfg.OTLPConfig.HTTPProxy == "" {
+		return
+	}
+
+	proxyURL, err := url.Parse(b.cfg.OTLPConfig.HTTPProxy)
+	if err != nil {
+		return
+	}
+
+	*opts = append(*opts, otlploghttp.WithProxy(func(req *http.Request) (*url.URL, error) {
+		return proxyURL, nil
+	}))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -407,6 +407,10 @@ func processOTLPConfig(config *Config, configMap map[string]any) error {
 		return err
 	}
 
+	if httpProxy, ok := configMap["httpproxy"].(string); ok && httpProxy != "" {
+		config.OTLPConfig.HTTPProxy = httpProxy
+	}
+
 	// Process TLS configuration fields
 	if certFile, ok := configMap["tlscertfile"].(string); ok && certFile != "" {
 		config.OTLPConfig.TLSCertFile = certFile

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -64,6 +64,9 @@ type OTLPConfig struct {
 	SDKBatchExportInterval     time.Duration `mapstructure:"SDKBatchExportInterval"`
 	SDKBatchExportMaxBatchSize int           `mapstructure:"SDKBatchExportMaxBatchSize"`
 
+	// HTTPProxy is the proxy URL for HTTP transport
+	HTTPProxy string `mapstructure:"HTTPProxy"`
+
 	// TLS configuration fields
 	TLSCertFile           string `mapstructure:"TLSCertFile"`
 	TLSKeyFile            string `mapstructure:"TLSKeyFile"`


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind technical-debt
/area logging

**What this PR does / why we need it**:
This PR fixes a few bugs in the configuration setup:
- 2 typos at “guessing” possible configuration keys: 
    - " dqueName"
    - "EndpointUrlPath:"
- Remove the obsolete `DeletedClientTimeExpiration` configuration option. It was introduced before `controller-runtime` and became silently unused after `0.37.0` release, when the old client-cleanup mechanism was removed. Previously, deleted clients were kept in a map and periodically cleaned up after a default one-hour timeout. With `controller-runtime`, deletions are handled synchronously in `Reconcile`. 
- Remove `HTTPPath`, duplicate of `EndpointURLPath`.
- Add implementation for `HTTPProxy`, which was previously skipped.

**Which issue(s) this PR fixes**:
Fixes #512

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Remove stale config keys (`DeletedClientTimeExpiration`, `HTTPPath`), fix typos in config keys (`DQueName`, `EndpointUrlPath`) and wire the previously-skipped `HTTPProxy` option for the OTLP HTTP exporter.
```
